### PR TITLE
Update deps and test swift 5.6

### DIFF
--- a/.github/workflows/Test-Linux.yml
+++ b/.github/workflows/Test-Linux.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["5.2", "5.4"]
+        swift: ["5.2", "5.6"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/Test-macOS.yml
+++ b/.github/workflows/Test-macOS.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["5.2", "5.4"]
+        swift: ["5.2", "5.6"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/Test-macOS.yml
+++ b/.github/workflows/Test-macOS.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Install swiftenv
       run: brew install kylef/formulae/swiftenv
     - name: Install and set swift@${{ matrix.swift }}
+      if: ${{ matrix.swift }} == "5.6"
       run: |
         swiftenv install ${{ matrix.swift }}
         swiftenv global ${{ matrix.swift }}

--- a/.github/workflows/Test-macOS.yml
+++ b/.github/workflows/Test-macOS.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install swiftenv
       run: brew install kylef/formulae/swiftenv
     - name: Install and set swift@${{ matrix.swift }}
-      if: ${{ matrix.swift }} == "5.6"
+      if: ${{ matrix.swift != "5.6" }}
       run: |
         swiftenv install ${{ matrix.swift }}
         swiftenv global ${{ matrix.swift }}

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,1 +1,2 @@
 --swiftversion 5.2
+--disable hoistTry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,14 @@
 ## 코딩 스타일
 
 이 프로젝트는 코드 포맷과 스타일을 강제하기 위해 [SwiftLint](https://github.com/realm/SwiftLint),
+[SwiftFormat](https://github.com/nicklockwood/SwiftFormat),
 [markdownlint](https://github.com/markdownlint/markdownlint),
 and [pre-commit](https://pre-commit.com/)
 를 사용합니다.
 
 ```
 brew install swiftlint
+brew install swiftformat
 gem install mdl
 brew install pre-commit
 pre-commit install
@@ -25,3 +27,22 @@ SwiftLint는 또한 모든 PR에서 CI로 확인됩니다.
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/b920b09bdee71fdc8208/maintainability)](https://codeclimate.com/github/sboh1214/Hwp-Swift/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/b920b09bdee71fdc8208/test_coverage)](https://codeclimate.com/github/sboh1214/Hwp-Swift/test_coverage)
+
+## 배포
+
+### Swift 버전이 새로 출시된 경우
+
+아래와 같은 파일의 Swift 버전을 업데이트합니다.
+
+- .github/workflows/Test-Linux.yml
+- .github/workflows/Test-macOS.yml
+
+### Minimum Swift 버전이 변경된 경우
+
+아래와 같은 파일의 Swift 버전을 업데이트합니다.
+
+- .github/workflows/Test-Linux.yml
+- .github/workflows/Test-macOS.yml
+- .swift-version
+- .swiftformat
+- Package.swift

--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/CoreOffice/OLEKit.git", .exact("0.3.1")),
-        .package(url: "https://github.com/tsolomko/SWCompression.git", .exact("4.6.0")),
+        .package(url: "https://github.com/tsolomko/SWCompression.git", .exact("4.8.5")),
 
-        .package(url: "https://github.com/Quick/Nimble", .exact("9.2.1")),
+        .package(url: "https://github.com/Quick/Nimble", .exact("11.2.1")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/CoreOffice/OLEKit.git", .exact("0.3.1")),
         .package(url: "https://github.com/tsolomko/SWCompression.git", .exact("4.8.5")),
 
-        .package(url: "https://github.com/Quick/Nimble", .exact("11.2.1")),
+        .package(url: "https://github.com/Quick/Nimble", .exact("9.2.1")),
     ],
     targets: [
         .target(

--- a/Sources/CoreHwp/Utils/Readers/DataReader.swift
+++ b/Sources/CoreHwp/Utils/Readers/DataReader.swift
@@ -40,7 +40,7 @@ struct DataReader {
         case is UInt32.Type, is Int32.Type:
             length = 4
         default:
-            precondition(false)
+            preconditionFailure()
             length = 4
         }
         let value = [UInt8](readBytes(length))


### PR DESCRIPTION
## Test CI Swift 버전 변경

- Swift 5.2, 5.4 -> 5.6 으로 변경
- Swift 5.6은 CI 환경에 기본 설치되어 있어 해당 사항 workflow 대응

## 기타

- SwiftFormat hoistTry 규칙 disable
- tsolomko/SWCompression 버전 업데이트
- 개발 환경 설정 및 배포 방법 작성
