### PR TITLE
ci: 타깃별 커버리지 게이트 일반화 및 HwpKitCore 하한 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,10 @@ jobs:
           python3 - <<'PY'
           from pathlib import Path
 
-          # 임계가 None인 경로는 값만 기록하고 실패시키지 않는다 (#106 관측 단계)
+          # 임계가 None인 경로는 값만 기록하고 실패시키지 않는다 (#106)
           targets = [
               ("Sources/CoreHwp/", 95.0),
-              ("Sources/HwpKitCore/", None),
+              ("Sources/HwpKitCore/", 91.0),
               ("Sources/HwpKitNative/", None),
               ("Sources/HwpKit/", None),
           ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,54 +22,88 @@ jobs:
           swift --version
           swift test --enable-code-coverage
       - name: Export lcov
+        # Release 번들은 커버리지 매핑이 없고 Debug-iphonesimulator 번들은 바이너리가
+        # 번들 루트에 있어 어느 쪽을 고르든 export가 실패한다. macOS Debug 산출물만
+        # 후보로 남긴 뒤 SF 레코드가 가장 많은 번들 하나를 골라 단독 export한다 —
+        # 공유 경로의 수치는 어느 번들로 뽑아도 같고, 번들마다 다른 것은 레코드의 유무다.
         run: |
           set -euo pipefail
           PROF_DATA=$(find .build -name 'default.profdata' -type f | head -1)
-          XCTEST_BUNDLE=$(find .build -name '*.xctest' -type d | head -1)
-          if [ -z "$XCTEST_BUNDLE" ]; then
-            echo "No XCTest bundle found" >&2
+          CANDIDATES=$(find .build -name '*.xctest' -type d | grep -E '/(Debug|debug)/' || true)
+          if [ -z "$CANDIDATES" ]; then
+            echo "No Debug XCTest bundle found" >&2
             exit 1
           fi
-          BIN_NAME=$(basename "$XCTEST_BUNDLE" .xctest)
-          BINARY="$XCTEST_BUNDLE/Contents/MacOS/$BIN_NAME"
-          if [ ! -x "$BINARY" ]; then
-            echo "No executable test binary found at $BINARY" >&2
+          CANDIDATE_LCOV=$(mktemp)
+          BEST_BUNDLE=""
+          BEST_COUNT=0
+          while IFS= read -r BUNDLE; do
+            BIN_NAME=$(basename "$BUNDLE" .xctest)
+            BINARY="$BUNDLE/Contents/MacOS/$BIN_NAME"
+            if [ ! -x "$BINARY" ]; then
+              echo "Skipping $BUNDLE: no executable test binary" >&2
+              continue
+            fi
+            if ! xcrun llvm-cov export -format=lcov "$BINARY" \
+              -instr-profile="$PROF_DATA" \
+              -ignore-filename-regex='(\.build|Tests/)' \
+              > "$CANDIDATE_LCOV"; then
+              echo "Skipping $BUNDLE: no coverage data" >&2
+              continue
+            fi
+            COUNT=$(grep -c '^SF:' "$CANDIDATE_LCOV" || true)
+            echo "$BUNDLE: $COUNT source files"
+            if [ "$COUNT" -gt "$BEST_COUNT" ]; then
+              BEST_COUNT=$COUNT
+              BEST_BUNDLE=$BUNDLE
+              cp "$CANDIDATE_LCOV" coverage.lcov
+            fi
+          done <<< "$CANDIDATES"
+          if [ -z "$BEST_BUNDLE" ]; then
+            echo "No coverage-instrumented test bundle found" >&2
             exit 1
           fi
-          xcrun llvm-cov export -format=lcov "$BINARY" \
-            -instr-profile="$PROF_DATA" \
-            -ignore-filename-regex='(\.build|Tests/)' \
-            > coverage.lcov
-      - name: Enforce CoreHwp coverage
+          echo "Selected $BEST_BUNDLE ($BEST_COUNT source files)"
+      - name: Enforce coverage thresholds
         run: |
           set -euo pipefail
           python3 - <<'PY'
           from pathlib import Path
 
-          threshold = 95.0
-          total_lines = 0
-          hit_lines = 0
-          include_file = False
+          # 임계가 None인 경로는 값만 기록하고 실패시키지 않는다 (#106 관측 단계)
+          targets = [
+              ("Sources/CoreHwp/", 95.0),
+              ("Sources/HwpKitCore/", None),
+              ("Sources/HwpKitNative/", None),
+              ("Sources/HwpKit/", None),
+          ]
+
+          totals = {path: [0, 0] for path, _ in targets}
+          current = None
 
           for line in Path("coverage.lcov").read_text(encoding="utf-8").splitlines():
               if line.startswith("SF:"):
-                  include_file = "Sources/CoreHwp/" in line
-              elif include_file and line.startswith("LF:"):
-                  total_lines += int(line.removeprefix("LF:"))
-              elif include_file and line.startswith("LH:"):
-                  hit_lines += int(line.removeprefix("LH:"))
+                  current = next((path for path, _ in targets if path in line), None)
+              elif current and line.startswith("LF:"):
+                  totals[current][0] += int(line.removeprefix("LF:"))
+              elif current and line.startswith("LH:"):
+                  totals[current][1] += int(line.removeprefix("LH:"))
               elif line == "end_of_record":
-                  include_file = False
+                  current = None
 
-          if total_lines == 0:
-              raise SystemExit("No Sources/CoreHwp coverage records found in coverage.lcov")
+          failures = []
+          for path, threshold in targets:
+              total_lines, hit_lines = totals[path]
+              if total_lines == 0:
+                  failures.append(f"No {path} coverage records found in coverage.lcov")
+                  continue
+              coverage = hit_lines * 100 / total_lines
+              print(f"{path} line coverage: {coverage:.2f}% ({hit_lines}/{total_lines})")
+              if threshold is not None and coverage < threshold:
+                  failures.append(f"{path} line coverage {coverage:.2f}% is below {threshold:.2f}%")
 
-          coverage = hit_lines * 100 / total_lines
-          print(f"CoreHwp line coverage: {coverage:.2f}% ({hit_lines}/{total_lines})")
-          if coverage < threshold:
-              raise SystemExit(
-                  f"CoreHwp line coverage {coverage:.2f}% is below {threshold:.2f}%"
-              )
+          if failures:
+              raise SystemExit("\n".join(failures))
           PY
       - uses: codecov/codecov-action@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ typed 디코더들이 그 트리를 재귀로 내려가므로(표 셀 문단·�
 ```bash
 swift build                                    # 빌드
 swift test                                     # 테스트 실행
-swift test --enable-code-coverage              # 커버리지 (lcov 추출·CoreHwp 95% 게이트는 .github/workflows/ci.yml의 coverage job)
+swift test --enable-code-coverage              # 커버리지 (lcov 추출·경로별 게이트는 .github/workflows/ci.yml Test (macOS) 잡의 스텝 — CoreHwp 95% 하드 게이트)
 HWP_PERF=1 swift test --filter Performance     # 성능 실측 (N=20,000 합성 + 타이트 임계; 기본은 N=1,000 스모크)
 HWP_SNAPSHOT_TESTS=1 swift test --filter "FixtureRenderHash|FixturePreviewFidelity"  # 환경 의존 스위트 (기본 swift test·CI에서는 skip)
 HWP_HANCOM_FONTS=1 swift test                  # 한컴오피스 번들 폰트 opt-in (기본 off — README "폰트"). 렌더 해시 기준선이 이 모드용으로 따로 있다

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ typed 디코더들이 그 트리를 재귀로 내려가므로(표 셀 문단·�
 ```bash
 swift build                                    # 빌드
 swift test                                     # 테스트 실행
-swift test --enable-code-coverage              # 커버리지 (lcov 추출·경로별 게이트는 .github/workflows/ci.yml Test (macOS) 잡의 스텝 — CoreHwp 95% 하드 게이트)
+swift test --enable-code-coverage              # 커버리지 (lcov 추출·경로별 게이트는 .github/workflows/ci.yml Test (macOS) 잡의 스텝 — CoreHwp 95%·HwpKitCore 91% 하드 게이트)
 HWP_PERF=1 swift test --filter Performance     # 성능 실측 (N=20,000 합성 + 타이트 임계; 기본은 N=1,000 스모크)
 HWP_SNAPSHOT_TESTS=1 swift test --filter "FixtureRenderHash|FixturePreviewFidelity"  # 환경 의존 스위트 (기본 swift test·CI에서는 skip)
 HWP_HANCOM_FONTS=1 swift test                  # 한컴오피스 번들 폰트 opt-in (기본 off — README "폰트"). 렌더 해시 기준선이 이 모드용으로 따로 있다

--- a/Sources/CoreHwp/AGENTS.md
+++ b/Sources/CoreHwp/AGENTS.md
@@ -154,11 +154,14 @@ payload를 읽기 전에 `HwpError.invalidRecordTree`로 거부합니다. 실문
 집계했을 때 line coverage는 98.60% (5481/5559), region coverage는
 97.56% (2483/2545)입니다.
 
-2026-07-23 기준으로 CI와 같은 방식(`llvm-cov export -format=lcov`에서
-`Sources/CoreHwp/`만 집계)으로 다시 재면 line coverage는 97.55%
-(7642/7834)입니다. `ci.yml`의 coverage job은 이 lcov 값이 95% 미만이면
-실패시킵니다. 테스트 번들이 4개여도 모든 테스트 타깃이 CoreHwp를 링크하므로
-어떤 번들을 export해도 같은 수치가 나옵니다.
+2026-08-19 기준으로 CI와 같은 방식(`llvm-cov export -format=lcov`에서
+`Sources/CoreHwp/`만 집계)으로 다시 재면 line coverage는 97.45%
+(8078/8289)입니다. `ci.yml` `Test (macOS)` 잡의 `Enforce coverage thresholds`
+스텝은 경로별 lcov line coverage를 재서 `Sources/CoreHwp/`가 95% 미만이면
+실패시키고, 나머지 세 경로(HwpKitCore·HwpKitNative·HwpKit)는 값만
+기록합니다. Export lcov 스텝은 macOS Debug 산출물 중 SF 레코드가 가장 많은
+테스트 번들 하나를 골라 export합니다 — 공유 경로의 수치는 어느 번들로 뽑아도
+같지만, 번들마다 담는 경로의 집합이 다르기 때문입니다.
 
 | 영역 | 상태 |
 | --- | --- |

--- a/Sources/CoreHwp/AGENTS.md
+++ b/Sources/CoreHwp/AGENTS.md
@@ -157,9 +157,9 @@ payload를 읽기 전에 `HwpError.invalidRecordTree`로 거부합니다. 실문
 2026-08-19 기준으로 CI와 같은 방식(`llvm-cov export -format=lcov`에서
 `Sources/CoreHwp/`만 집계)으로 다시 재면 line coverage는 97.45%
 (8078/8289)입니다. `ci.yml` `Test (macOS)` 잡의 `Enforce coverage thresholds`
-스텝은 경로별 lcov line coverage를 재서 `Sources/CoreHwp/`가 95% 미만이면
-실패시키고, 나머지 세 경로(HwpKitCore·HwpKitNative·HwpKit)는 값만
-기록합니다. Export lcov 스텝은 macOS Debug 산출물 중 SF 레코드가 가장 많은
+스텝은 경로별 lcov line coverage를 재서 `Sources/CoreHwp/`가 95%,
+`Sources/HwpKitCore/`가 91% 미만이면 실패시키고, HwpKitNative·HwpKit 두
+경로는 값만 기록합니다. Export lcov 스텝은 macOS Debug 산출물 중 SF 레코드가 가장 많은
 테스트 번들 하나를 골라 export합니다 — 공유 경로의 수치는 어느 번들로 뽑아도
 같지만, 번들마다 담는 경로의 집합이 다르기 때문입니다.
 

--- a/Tests/CoreHwpTests/Utils/Project/CoverageWorkflowTests.swift
+++ b/Tests/CoreHwpTests/Utils/Project/CoverageWorkflowTests.swift
@@ -3,24 +3,50 @@ import Nimble
 import XCTest
 
 final class CoverageWorkflowTests: XCTestCase {
-    func testCoverageWorkflowEnforcesCoreHwpLineCoverageThreshold() throws {
+    func testCoverageWorkflowSelectsCoverageInstrumentedDebugBundle() throws {
         let workflow = try String(contentsOf: coverageWorkflowURL(), encoding: .utf8)
 
-        expect(workflow).to(contain("Enforce CoreHwp coverage"))
-        expect(workflow).to(contain("coverage.lcov"))
-        expect(workflow).to(contain("Sources/CoreHwp/"))
-        expect(workflow).to(contain("CoreHwp line coverage"))
-        expect(workflow).to(contain("coverage < threshold"))
+        // Release·Debug-iphonesimulator 산출물을 배제하고 SF 레코드가 가장 많은
+        // macOS Debug 번들 하나를 골라 export한다 (#106). 병합 번들 이름 하드코딩은
+        // 두 빌드 시스템 중 한쪽에서 반드시 깨지므로 금지한다.
         expect(workflow).to(contain("find .build -name '*.xctest' -type d"))
+        expect(workflow).to(contain("grep -E '/(Debug|debug)/'"))
         expect(workflow).notTo(contain("*PackageTests.xctest"))
-        expect(workflow).to(contain("No XCTest bundle found"))
-        expect(workflow).to(contain("No executable test binary found"))
+        expect(workflow).to(contain("No Debug XCTest bundle found"))
+        expect(workflow).to(contain("No coverage-instrumented test bundle found"))
+        expect(workflow).to(contain("coverage.lcov"))
+    }
 
-        guard let threshold = coverageThreshold(in: workflow) else {
-            return fail("Expected CI workflow to declare a numeric CoreHwp coverage threshold")
+    func testCoverageWorkflowEnforcesPerPathLineCoverageThresholds() throws {
+        let workflow = try String(contentsOf: coverageWorkflowURL(), encoding: .utf8)
+
+        expect(workflow).to(contain("Enforce coverage thresholds"))
+        expect(workflow).to(contain("coverage < threshold"))
+
+        // 관측 전용 경로의 수치 기록(print)과 임계 미달의 실패 수집(append)·보고(raise)를
+        // 각각 따로 고정한다 — 셋 중 하나만 무력화해도 게이트나 관측이 조용히 죽는다.
+        expect(workflow).to(contain(#"print(f"{path} line coverage: "#))
+        expect(workflow).to(contain(#"failures.append(f"{path} line coverage"#))
+        expect(workflow).to(contain("is below"))
+        expect(workflow).to(contain(#"raise SystemExit("\n".join(failures))"#))
+
+        let targets = coverageTargets(in: workflow)
+        expect(targets.map(\.path)) == [
+            "Sources/CoreHwp/",
+            "Sources/HwpKitCore/",
+            "Sources/HwpKitNative/",
+            "Sources/HwpKit/",
+        ]
+
+        guard let coreHwp = targets.first(where: { $0.path == "Sources/CoreHwp/" }),
+              let threshold = coreHwp.threshold
+        else {
+            return fail(
+                "Expected CI workflow to declare a numeric Sources/CoreHwp/ coverage threshold"
+            )
         }
 
-        expect(threshold >= 95.0) == true
+        expect(threshold).to(beGreaterThanOrEqualTo(95.0))
     }
 }
 
@@ -33,17 +59,24 @@ private func coverageWorkflowURL() -> URL {
         .appendingPathComponent("ci.yml")
 }
 
-private func coverageThreshold(in workflow: String) -> Double? {
-    guard let range = workflow.range(
-        of: #"threshold\s*=\s*[0-9]+(\.[0-9]+)?"#,
-        options: .regularExpression
-    ) else {
-        return nil
+/// 게이트 스텝의 `("<경로>", <임계|None>)` 쌍 목록을 선언 순서대로 파싱한다.
+/// `None`(관측 전용)은 threshold nil로 나타낸다.
+private func coverageTargets(in workflow: String) -> [(path: String, threshold: Double?)] {
+    let pattern = #"\("(Sources/[A-Za-z]+/)",\s*(None|[0-9]+(?:\.[0-9]+)?)\)"#
+    guard let regex = try? NSRegularExpression(pattern: pattern) else {
+        return []
     }
 
-    let assignment = workflow[range]
-    guard let value = assignment.split(separator: "=").last else {
-        return nil
+    let fullRange = NSRange(workflow.startIndex..., in: workflow)
+    return regex.matches(in: workflow, range: fullRange).compactMap { match in
+        guard let pathRange = Range(match.range(at: 1), in: workflow),
+              let valueRange = Range(match.range(at: 2), in: workflow)
+        else {
+            return nil
+        }
+        return (
+            path: String(workflow[pathRange]),
+            threshold: Double(workflow[valueRange])
+        )
     }
-    return Double(value.trimmingCharacters(in: .whitespacesAndNewlines))
 }

--- a/Tests/CoreHwpTests/Utils/Project/CoverageWorkflowTests.swift
+++ b/Tests/CoreHwpTests/Utils/Project/CoverageWorkflowTests.swift
@@ -39,14 +39,24 @@ final class CoverageWorkflowTests: XCTestCase {
         ]
 
         guard let coreHwp = targets.first(where: { $0.path == "Sources/CoreHwp/" }),
-              let threshold = coreHwp.threshold
+              let coreHwpThreshold = coreHwp.threshold
         else {
             return fail(
                 "Expected CI workflow to declare a numeric Sources/CoreHwp/ coverage threshold"
             )
         }
 
-        expect(threshold).to(beGreaterThanOrEqualTo(95.0))
+        expect(coreHwpThreshold).to(beGreaterThanOrEqualTo(95.0))
+
+        guard let hwpKitCore = targets.first(where: { $0.path == "Sources/HwpKitCore/" }),
+              let hwpKitCoreThreshold = hwpKitCore.threshold
+        else {
+            return fail(
+                "Expected CI workflow to declare a numeric Sources/HwpKitCore/ coverage threshold"
+            )
+        }
+
+        expect(hwpKitCoreThreshold).to(beGreaterThanOrEqualTo(91.0))
     }
 }
 


### PR DESCRIPTION
Closes #106

## 변경 사항

- **`Export lcov` 번들 선택 기준 고정** — `head -1`로 첫 번들을 고르는 대신 macOS Debug 산출물(`/(Debug|debug)/`)만 후보로 남깁니다. 각 후보의 lcov를 내보낸 뒤 `SF:` 레코드가 가장 많은 번들 하나를 `coverage.lcov`로 선택합니다. 커버리지 매핑이 없는 번들은 건너뛰고, 선택한 번들 경로는 로그에 기록합니다. 사용할 수 있는 후보가 없으면 실패합니다. 번들 이름은 하드코딩하지 않으며, `*PackageTests.xctest` 하드코딩을 금지하는 기존 가드도 유지합니다.
- **게이트를 `(경로, 하한)` 목록으로 일반화** — `Sources/CoreHwp/`의 95.0% 하한을 유지하고 `Sources/HwpKitCore/`에 91.0% 하한을 추가합니다. `Sources/HwpKitNative/`와 `Sources/HwpKit/`은 하한 없이 값만 기록합니다. 모든 경로를 측정한 뒤 실패 사유를 모아 한 번에 보고하며, 레코드가 0인 경로는 하한 유무와 관계없이 실패합니다. `SF:` 레코드의 경로 부분문자열 판정은 유지합니다.
- **`CoverageWorkflowTests` 재작성** — 파일에서 첫 번째 `threshold =` 매치 하나만 읽던 정규식을 버리고 `targets` 목록을 파싱해 네 경로의 선언 순서와 `CoreHwp ≥ 95.0`, `HwpKitCore ≥ 91.0`을 검증합니다. 관측 로그 출력, 실패 누적, 최종 `raise`를 각각 고정해 어느 하나가 제거돼도 테스트가 실패하도록 했습니다.
- **문서** — “coverage job”이라고 적힌 두 곳을 `Test (macOS)` 잡의 스텝으로 바로잡고, `Sources/CoreHwp/AGENTS.md`의 lcov 문단을 새 실측값(97.45%, 8078/8289)과 번들 선택 규칙에 맞게 갱신했습니다. 가드가 리터럴로 고정한 2026-06-28 문단과 `Fixtures/README.md`는 건드리지 않았습니다.

## HwpKitCore 하한: 91.0 확정

첫 PR CI 실행(run 32265397197)에서 #106 절차 1의 관측값을 얻었습니다.

| 경로 | CI | 로컬 | 격차 |
|---|---|---|---|
| CoreHwp | 97.45% (8078/8289) | 97.45% (8078/8289) | 0.00%p (분자·분모 동일) |
| **HwpKitCore** | **93.37% (13710/14684)** | 93.76% (13767/14684) | 0.39%p (57줄, 분모 동일) |
| HwpKitNative | 84.36% | 84.41% | 0.05%p |
| HwpKit | 78.92% (569/721) | 78.92% | 0.00%p |

CI의 SwiftPM 네이티브 빌드에서도 병합 번들 `arm64-apple-macosx/debug/Hwp-SwiftPackageTests.xctest`를 선택했고, 205개의 `SF:` 레코드를 내보냈습니다. CI와 로컬의 HwpKitCore 격차는 0.39%p로 확인됐습니다. 따라서 #106 절차 3의 “격차가 작으면 −2~3%p” 기준에 따라 하한을 **91.0%**로 확정했습니다. CI 실측보다 2.37%p 낮아 348줄의 여유가 있습니다. CoreHwp 게이트 도입 당시의 3.60%p 여유와 비슷한 범위이며, 실행 간 변동 폭 0.03%p보다 충분히 큽니다. 가드 테스트에도 CoreHwp와 마찬가지로 HwpKitCore ≥ 91.0을 고정했습니다. HwpKitNative(iOS 전용 6개 파일이 macOS lcov에 없음)와 HwpKit(분모 721줄)은 계획대로 관측 전용으로 남깁니다.

## 검증

- 로컬 `.build`의 번들 12개를 대상으로 새 `Export lcov` 스크립트가 `Debug/HwpKitTests.xctest`(205개 `SF:` 레코드)를 선택했습니다. Release 번들을 후보에 강제로 포함하면 “no coverage data”로 건너뛴 뒤 같은 번들을 선택했고, 후보가 없으면 exit 1로 종료했습니다.
- 게이트 통과: 네 경로의 수치가 #106 실측 표와 일치했습니다(CoreHwp 97.45% 8078/8289 · HwpKitCore 93.76% · HwpKitNative 84.41% · HwpKit 78.92%). 두 번 실행해 같은 수치가 나오는 것도 확인했습니다.
- 게이트 실패: 커버리지 하한 미달 2건과 레코드 없음 1건을 누적해 한 번에 보고하고 exit 1로 종료했습니다.
- `ci.yml` 변형 8종(스텝 개명·하한을 90.0으로 낮춤·경로 삭제·하한을 `None`으로 변경·Debug 필터 제거·`raise` 삭제·`append`를 `print`로 변경·관측용 `print` 제거)에서 모두 가드가 실패했고, 원상 복구 후 통과했습니다.
- `swift test --enable-code-coverage` 전체 스위트가 실패 없이 통과했습니다(문서 가드 3종 포함). `swiftformat --lint .`과 `swiftlint`도 모두 통과했습니다.
- Bash·Python·Swift 테스트·문서 가드·이슈 대조의 다섯 관점에서 병렬로 검토하고 발견 사항별 변이 검증을 수행했습니다. 그 결과 가드 허점 2건(`raise` 삭제 시 실패가 보고되지 않는 문제와 관측용 `print` 삭제 시 출력이 사라지는 문제)을 찾아 검사 항목을 추가했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
