### PR TITLE
feat(parser): 손상 문단, 구역 부분 복구와 파서 안정성 보강 (#65, #67)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,15 @@ typed 디코더들이 그 트리를 재귀로 내려가므로(표 셀 문단·�
   (sectionDef+column 컨트롤)을 채워 조판 전제를 지키고 **구역 수를 보존**해 뒤
   구역 자리가 밀리지 않게 한다. 원본 구역 스트림은 보존 모드 한정으로
   (`preservedPayload` 게이트) `rawPayload`에 실어 재파싱 근거를 남긴다.
+- **구역의 첫 문단 손상은 문단이 아니라 구역 단위로 승격된다** (#110).
+  `sectionDef`는 구역의 첫 문단에만 붙는데 (`blankDocumentParagraph`),
+  paginator는 `sectionDef(in:)` **하나로만** 구역 경계를 인식한다
+  (`flushPageBeforeProcessing`·`applySectionDef` — `nextSectionIndex` 전진은
+  지오메트리에 아무 영향이 없다). 첫 문단을 sectionDef 없는 문단 placeholder로
+  삼키면 그 구역이 **앞 구역의 종이·여백·단·번호로 조판된다**. 그래서
+  `HwpSection.load`의 문단 루프는 `paragraphs.isEmpty`일 때 복구를 건너뛰고
+  전파해, `HwpFile`이 구역 단위 placeholder로 승격시킨다. 중간·뒤 문단 손상은
+  종전대로 문단 placeholder다 (그 자리엔 sectionDef가 없으므로 경계가 안전).
 - **진단은 `parseFailure: String?` 필드다** — `HwpParagraph.parseFailure` /
   `HwpSection.parseFailure`. 정상 파싱은 nil. **Equatable/Hashable에 참여한다**:
   placeholder와 진짜 빈 문단/구역이 같다고 판정되면 복구 흔적이 비교에서

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # 프로젝트 지식 베이스
 
-**Branch:** feat/page-bitmap-render-thumbnails
+**Branch:** feat/partial-content-recovery
 
 ## 개요
 
@@ -51,7 +51,7 @@ hwp-swift/
 | 심볼 | 위치 | 역할 |
 |------|------|------|
 | `HwpFile` | [HwpFile.swift](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/HwpFile.swift) | 유일한 public 진입점: `init(fromPath:)`/`init(fromData:)`/`init(fromWrapper:)` (각각 `readLimits:` 또는 `options:` 오버로드), `init()` |
-| `HwpLoadOptions` | [HwpLoadOptions.swift](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/HwpLoadOptions.swift) | `readLimits` + `preserveRawPayload`(기본 true). `.viewer` 프리셋은 rawPayload 보존을 꺼 압축 해제 버퍼를 파싱 후 즉시 해제 (뷰어 상주 메모리 대폭 절감) |
+| `HwpLoadOptions` | [HwpLoadOptions.swift](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/HwpLoadOptions.swift) | `readLimits` + `preserveRawPayload`(기본 true) + `recoverPartialContent`(기본 false — 아래 "부분 복구"). `.viewer` 프리셋은 rawPayload 보존을 끄고 (압축 해제 버퍼를 파싱 후 즉시 해제 — 뷰어 상주 메모리 대폭 절감) 부분 복구를 켠다 |
 | `HwpError` | [HwpError.swift](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/HwpError.swift) | `CustomStringConvertible` + `LocalizedError`를 채택한 public error enum |
 | `HwpStreamName` | [Enums/HwpStreamName.swift](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/Enums/HwpStreamName.swift) | OLE stream 이름 (`FileHeader`, `DocInfo`, `BodyText`, `\005HwpSummaryInformation`, `PrvText`, `PrvImage`) |
 | `parseTreeRecord` | [Utils/HwpRecord.swift](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/Utils/HwpRecord.swift) | stream에서 tag/level/size record tree를 구성 |
@@ -103,6 +103,60 @@ typed 디코더들이 그 트리를 재귀로 내려가므로(표 셀 문단·�
 모델에 depth를 부착하거나 `load` 시그니처를 바꿀 필요가 없다. 가드는 payload와
 확장 크기를 읽기 **전**에 있어 조작 입력이 할당을 유도하지 못한다. 전 픽스처
 실측 최대 level은 5이며, 회귀 테스트가 `maxNestingDepth: 8`로 이를 잠근다.
+
+## 부분 복구 (#65·#67)
+
+`HwpLoadOptions.recoverPartialContent`(기본 **false**)가 켜지면 손상 문단·구역이
+문서 전체를 실패시키는 대신 **placeholder로 대체**되고 나머지 본문이 살아난다.
+기본 모드는 종전 그대로 fail-fast다. `.viewer` 프리셋은 이 옵션을 켠다 — 한
+문단 손상으로 뷰어가 백지가 되는 대신 나머지를 그리는 쪽이 낫다. **복구는
+`CoreHwp` 파서에만 있다 — `HwpKit`/뷰어에 새 공개 API는 없다** (진단 노출은
+아래 `HwpPaginator` 경유).
+
+- **placeholder의 형태가 층마다 다르다.** 문단 placeholder
+  (`HwpParagraph.parseFailurePlaceholder`)는 `paraText == nil`(하류 run builder가
+  빈 문단으로 처리)에 원본 레코드를 `unknownChildren`에 통째로 보존한다. 구역
+  placeholder(`HwpSection.parseFailurePlaceholder`)는 빈 문서 템플릿 문단
+  (sectionDef+column 컨트롤)을 채워 조판 전제를 지키고 **구역 수를 보존**해 뒤
+  구역 자리가 밀리지 않게 한다. 원본 구역 스트림은 보존 모드 한정으로
+  (`preservedPayload` 게이트) `rawPayload`에 실어 재파싱 근거를 남긴다.
+- **진단은 `parseFailure: String?` 필드다** — `HwpParagraph.parseFailure` /
+  `HwpSection.parseFailure`. 정상 파싱은 nil. **Equatable/Hashable에 참여한다**:
+  placeholder와 진짜 빈 문단/구역이 같다고 판정되면 복구 흔적이 비교에서
+  지워지기 때문이다. 별도 `HwpRecoveryDiagnostic` 타입은 없다.
+- **recovery-exempt는 3종이다** (`HwpError.isRecoveryExempt`):
+  자원 한도 2종(`streamSizeLimitExceeded`·`aggregateStreamSizeLimitExceeded`)에
+  더해 **`unsupportedFeature`**(암호·배포용·DRM — 뷰어가 그릴 수 있는 최소
+  전제). 이 3종은 복구 모드에서도 placeholder로 삼키지 않고 그대로 throw한다.
+  집합 멤버십은 `HwpErrorTests.testRecoveryExemptSetCoversResourceLimitsAndUnsupportedFeature`
+  가 `HwpError` 케이스 단위로 고정한다 (exempt 3종 + `invalidRecordTree`는
+  **비-exempt**로 명시) — **구조 손상은 복구 대상**이다.
+- **메모 문단도 복구된다.** 손상 메모 문단을 그대로 전파시키면 호스트 문단
+  전체가 placeholder가 되어 본문 텍스트까지 잃고 메모 그룹 경계도 사라진다.
+  그래서 `HwpParagraph.load`의 메모 수집 루프가 메모 문단을 개별 placeholder로
+  대체한다.
+- **ViewText에는 복구를 켜지 않는다** (`HwpFile.parseViewSections`가
+  `recoverPartialContent = false`로 강제). 표시본은 구역 하나라도 실패하면
+  **전량 폐기해 BodyText로 강등**하는 기존 채택 규칙을 유지한다 — placeholder로
+  개수를 보존하면 불완전 표시본이 채택 규칙(`displaySectionArray`)을 통과해 그
+  구역을 백지로 만든다. `ViewText`의 "실패 시 빈 배열 폴백"은 종전 그대로다.
+- **뷰어 진단 노출**: placeholder는 `HwpPaginator.unsupportedElements()`에
+  `kind: .placeholder`로 나온다 — "손상 문단/구역/메모 문단 복구 (파싱 실패:
+  …)". 복구가 내용을 조용히 숨기지 않게 하는 채널이다 (렌더는 placeholder의 빈
+  텍스트를 그리지 않으므로 이 보고가 유일한 흔적). 메모 placeholder는 호스트
+  문단이 정상 파싱돼 `parseFailure`로는 안 드러나므로 paginator가 메모 그룹과
+  컨트롤 안 중첩 문단(표 셀·리스트·글상자)까지 재귀로 훑는다. 배너 UI는
+  호스트 몫이다.
+
+**#67이 같은 브랜치에 있는 이유는 복구의 인접 정리라서다** —
+`HwpParaText.wcharCount`가 문단당 `reduce` 재계산에서 **파스 루프 누적 저장값**
+으로 바뀌었다 (값·공개 API 동일, `charArray` 변경 시 didSet 재동기화). 파생값
+이라 custom Codable로 인코딩 형상은 그대로(`rawPayload`/`charArray` 두 키)이고,
+Equatable/Hashable에서도 제외된다 (payload **유무** 파생이라 `HwpChar` 동등성과
+어긋날 수 있음 — 빈 템플릿 vs 파싱본 round-trip 동등성이 이에 기댄다). 표 셀
+헤더의 **도달 불가능한** 음수 `paragraphCount` 가드도 제거됐다 — 표 셀은
+`UInt16`을 `Int32`로 승격해 읽어 항상 비음수다 (리스트/글상자와 달리 bytes 6-7이
+셀 확장 속성이라 읽기 폭을 넓힐 수 없다는 근거를 주석으로 못박음). 되살리지 말 것.
 
 ## 컨벤션
 
@@ -914,4 +968,4 @@ opt-in — **커밋된** 기준선을 쓰는 스위트는 CI에서 상시 돈다
 - `HwpFile.init()`는 완전 빈 객체가 아니라 빈 `HwpSection` 하나가 들어있는 default 객체를 만든다. `Tests/CoreHwpTests/Blank/Create*Tests.swift`에서 파싱된 픽스처와 비교할 때 이를 사용.
 - `Streams/HwpDocInfo.swift`의 여러 `// TODO: HWPTAG_*` 주석은 의도된 것으로, 아직 구현되지 않은 기능이다. 리팩토링 중에 조용히 제거하지 말 것.
 - `HwpCtrlId` enum의 `Codable`은 hand-rolled 구현이다. 이종(heterogeneous) payload를 가진 associated value enum은 Swift가 자동 합성하지 못하기 때문.
-- **Codable 아카이브 호환**: 모델에 새 저장 필드를 추가하면 이전 아카이브(키 부재)가 `keyNotFound`로 깨지거나, 더 나쁘게는 파생 필드가 nil로 조용히 유실된다. 신규 필드는 custom `init(from:)`에서 `decodeIfPresent ?? 기본값`으로 받고, **파싱에서 파생되는 typed 필드는 원본(raw payload/RawValue)에서 파스와 같은 함수로 재수화**한다 (`HwpFile.viewSectionArray`, `HwpBullet.headCharShapeId`, `HwpChar.inlineControl`, `HwpCommonCtrlPropertyInfo`의 enum 9종, `HwpTableCellHeader.cellProperty`, `HwpOtherControl`의 typed payload 6종, `HwpShapeComponent.textBoxListArray`의 `textBoxInfo`). 재수화는 **파스 게이트까지 같아야** 한다 — 예로 글상자 리스트만 표 90을 갖는 규약이라, 재수화도 부모 `HwpShapeComponent` 디코더에서만 수행한다. 회귀 가드는 `Tests/CoreHwpTests/Stability/LegacyArchiveDecodingTests.swift`.
+- **Codable 아카이브 호환**: 모델에 새 저장 필드를 추가하면 이전 아카이브(키 부재)가 `keyNotFound`로 깨지거나, 더 나쁘게는 파생 필드가 nil로 조용히 유실된다. 신규 필드는 custom `init(from:)`에서 `decodeIfPresent ?? 기본값`으로 받고, **파싱에서 파생되는 typed 필드는 원본(raw payload/RawValue)에서 파스와 같은 함수로 재수화**한다 (`HwpFile.viewSectionArray`, `HwpBullet.headCharShapeId`, `HwpChar.inlineControl`, `HwpCommonCtrlPropertyInfo`의 enum 9종, `HwpTableCellHeader.cellProperty`, `HwpOtherControl`의 typed payload 6종, `HwpShapeComponent.textBoxListArray`의 `textBoxInfo`). 재수화는 **파스 게이트까지 같아야** 한다 — 예로 글상자 리스트만 표 90을 갖는 규약이라, 재수화도 부모 `HwpShapeComponent` 디코더에서만 수행한다. 회귀 가드는 `Tests/CoreHwpTests/Stability/LegacyArchiveDecodingTests.swift`. 두 부류의 신규 필드는 이 재수화 규칙에서 갈린다 (#65·#67): ① `HwpSection.parseFailure`/`HwpParagraph.parseFailure`는 raw payload의 파생이 아니라 **로드 사건의 기록**이라 재수화하지 않고 아카이브 값 그대로가 진실이다 (`decodeIfPresent ?? nil`). ② `HwpParaText.wcharCount`는 `charArray`에서 파생되지만 **인코딩하지 않고**(custom `CodingKeys`가 `rawPayload`/`charArray` 두 키만) 디코더의 `init(rawPayload:charArray:)`가 재계산한다 — 파생값을 아카이브에 싣지 않는 반대 방향의 처리다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@
 
 ### Changed
 
+- `HwpParaText.wcharCount`가 문단당 reduce 재계산에서 **파스 루프 누적 저장값**
+  으로 바뀌었습니다 (#67). 값·공개 API는 동일하고(`charArray` 변경 시 didSet
+  재동기화), 파생값이므로 custom Codable로 인코딩 형상(`rawPayload`/`charArray`
+  두 키)은 그대로입니다.
+- 표 셀 헤더의 도달 불가능한 음수 `paragraphCount` 가드를 제거했습니다 (#67).
+  표 셀 파싱은 `UInt16`을 `Int32`로 승격해 읽어 항상 비음수입니다 — 리스트/
+  글상자와 달리 표 셀 헤더는 bytes 6-7이 셀 확장 속성이라 읽기 폭을 `Int32`로
+  넓힐 수 없다는 근거를 주석으로 못박았습니다. 동작 변화는 없습니다.
 - 책갈피 컨트롤(`bokm`)이 더 이상 **미지원 요소로 보고되지 않습니다**
   (`HwpUnsupportedDetector` → nil). 화면 출력이 없는 앵커이고, 이제 탐색 목록
   (`HwpDocumentMetadata.outline`)의 재료로 소비되기 때문입니다. 책갈피가 있는
@@ -114,6 +122,23 @@
 
 ### Added
 
+- **손상 문단·구역 best-effort 복구**가 들어왔습니다 (#65).
+  `HwpLoadOptions.recoverPartialContent`(기본 `false`)를 켜면 문단 카운트
+  불일치·필수 레코드 누락 같은 문단 파싱 실패, 그리고 구역 스트림 파싱 실패가
+  문서 전체를 실패시키는 대신 placeholder(문단은 `paraText == nil` + 원본
+  레코드 `unknownChildren` 보존, 구역은 빈 문서 템플릿 문단)로 대체되고, 새
+  public 필드 `HwpParagraph.parseFailure`/`HwpSection.parseFailure`에 원인이
+  남습니다. 손상 메모 문단도 같은 방식으로 복구되어 메모 그룹 경계가
+  보존됩니다. `.viewer` 프리셋은 이 옵션을 켜므로 뷰어는 한 문단 손상으로
+  백지가 되는 대신 나머지 본문을 그리고, placeholder는
+  `HwpPaginator.unsupportedElements()`에 "손상 문단/구역 복구" 진단으로
+  노출됩니다. 기본 모드는 종전 그대로 fail-fast입니다. FileHeader
+  `unsupportedFeature`(암호·배포용·DRM)와 자원 한도
+  2종(`streamSizeLimitExceeded`·`aggregateStreamSizeLimitExceeded`)은 복구
+  모드에서도 계속 throw되며, ViewText(표시본)는 복구를 적용하지 않고 구역
+  하나라도 실패하면 전량 폐기해 BodyText로 강등하는 기존 채택 규칙을
+  유지합니다 — placeholder로 개수를 보존하면 불완전 표시본이 채택되어 해당
+  구역이 백지가 되기 때문입니다.
 - **문서 뷰 VoiceOver 지원**이 들어왔습니다 (#79). 문서 본문은 뷰가 아니라
   `CALayer`로 그려져 지금까지 AX 트리가 없었는데, 이제 두 네이티브 뷰가 가시
   (±2) 페이지의 텍스트를 접근성 요소로 합성합니다 — 본문 단위(선택과 같은

--- a/Sources/CoreHwp/AGENTS.md
+++ b/Sources/CoreHwp/AGENTS.md
@@ -99,7 +99,12 @@ ID로 dispatch된다.
 ## 안티 패턴
 
 - 모델 안에서 `HwpError`를 catch해서 default 값을 반환 — `HwpFile.init`까지
-  전파시킬 것.
+  전파시킬 것. **명시 예외 (#65)**: `HwpLoadOptions.recoverPartialContent`가
+  켜진 경우의 문단·구역·메모 문단 placeholder 대체
+  (`HwpParagraph.parseFailurePlaceholder`/`HwpSection.parseFailurePlaceholder`,
+  게이트는 `error.isRecoveryExempt`). 이때도 default 값이 아니라 `parseFailure`
+  진단과 원본 레코드(`unknownChildren`)를 남기는 placeholder여야 하고, 기본
+  모드는 계속 fail-fast다. 이 예외를 다른 모델·다른 error로 넓히지 말 것.
 - 이유 없는 `load(...)` override 또는 `reader.readToEnd()` 호출 — EOF 검사를
   우회한다. raw 보존, record-tree 파싱, tag 검증 같은 예외 목적이 명확해야 한다.
 - `Sources/`에 `import XCTest`, `@testable`, Nimble 추가 — 모두 금지.

--- a/Sources/CoreHwp/HwpError.swift
+++ b/Sources/CoreHwp/HwpError.swift
@@ -90,6 +90,21 @@ extension HwpError: CustomStringConvertible {
 }
 
 extension HwpError {
+    /// `HwpLoadOptions.recoverPartialContent`가 켜져도 placeholder로 삼키지
+    /// 않고 전파하는 오류 — 자원 한도 2종은 설정된 하드 한계이고,
+    /// `unsupportedFeature`는 뷰어가 그릴 수 있는 최소 전제다
+    /// (`HwpFile`의 ViewText read 폴백과 같은 분류, P1).
+    var isRecoveryExempt: Bool {
+        switch self {
+        case .streamSizeLimitExceeded, .aggregateStreamSizeLimitExceeded, .unsupportedFeature:
+            true
+        default:
+            false
+        }
+    }
+}
+
+extension HwpError {
     static func bytesAreNotEOF(model: Any, remain: Int) -> HwpError {
         .bytesAreNotEOF(modelName: hwpErrorModelName(model), remain: remain)
     }

--- a/Sources/CoreHwp/HwpFile.swift
+++ b/Sources/CoreHwp/HwpFile.swift
@@ -253,7 +253,10 @@ public struct HwpFile: HwpPrimitive {
             } catch let error as HwpError
                 where options.recoverPartialContent && !error.isRecoveryExempt
             {
-                return HwpSection.parseFailurePlaceholder(error: error)
+                return HwpSection.parseFailurePlaceholder(
+                    error: error,
+                    rawPayload: options.preservedPayload($0)
+                )
             }
         }
         viewSectionArray = Self.parseViewSections(

--- a/Sources/CoreHwp/HwpFile.swift
+++ b/Sources/CoreHwp/HwpFile.swift
@@ -245,25 +245,23 @@ public struct HwpFile: HwpPrimitive {
             )
         }
         sectionArray = try sectionDataArray.map {
-            try HwpSection.load($0, fileHeader.version, options: options)
-        }
-        // 표시용 본문 (ViewText): 이름이 Section0…Section{N-1}과 정확히
-        // (개수·연속·중복 없이) 일치할 때만 best-effort 파싱한다. 개수만 같고
-        // 이름이 누락/중복/비-section이면 BodyText 구역을 조용히 잘못 대체하므로
-        // 무시한다 (#17). 파싱 실패 시에도 BodyText 렌더로 폴백한다.
-        let sortedViewText = viewTextData.sorted { lhs, rhs in
-            Self.sectionIndex(from: lhs.name) < Self.sectionIndex(from: rhs.name)
-        }
-        if sortedViewText.map(\.name) == (0 ..< expectedSectionCount).map({ "Section\($0)" }) {
+            // 복구 모드에서는 구역 하나의 파싱 실패가 문서 전체를 실패시키지
+            // 않도록 placeholder 구역으로 대체한다. 자원 한도 등
+            // recovery-exempt 오류는 계속 전파한다 (#65).
             do {
-                viewSectionArray = try sortedViewText
-                    .map { try HwpSection.load($0.data, fileHeader.version, options: options) }
-            } catch {
-                viewSectionArray = []
+                return try HwpSection.load($0, fileHeader.version, options: options)
+            } catch let error as HwpError
+                where options.recoverPartialContent && !error.isRecoveryExempt
+            {
+                return HwpSection.parseFailurePlaceholder(error: error)
             }
-        } else {
-            viewSectionArray = []
         }
+        viewSectionArray = Self.parseViewSections(
+            viewTextData,
+            expectedSectionCount: expectedSectionCount,
+            version: fileHeader.version,
+            options: options
+        )
 
         if let summaryData {
             summary = try HwpSummary.load(summaryData, options: options)
@@ -284,6 +282,40 @@ public struct HwpFile: HwpPrimitive {
         }
 
         binaryDataArray = binaryData.map { HwpBinaryData(name: $0.name, data: $0.data) }
+    }
+
+    /// 표시용 본문 (ViewText): 이름이 Section0…Section{N-1}과 정확히
+    /// (개수·연속·중복 없이) 일치할 때만 best-effort 파싱한다. 개수만 같고
+    /// 이름이 누락/중복/비-section이면 BodyText 구역을 조용히 잘못 대체하므로
+    /// 무시한다 (#17). 파싱 실패 시에도 BodyText 렌더로 폴백한다.
+    ///
+    /// ViewText에는 복구를 켜지 않는다 — 실패 구역·문단을 placeholder로
+    /// 채우면 개수 보존 탓에 채택 규칙(`displaySectionArray`)을 통과한
+    /// 불완전 표시본이 그 구역을 백지로 만든다. BodyText 복구본으로
+    /// 강등하는 기존 전량 폐기가 안전하다 (#65).
+    private static func parseViewSections(
+        _ viewTextData: [(name: String, data: Data)],
+        expectedSectionCount: Int,
+        version: HwpVersion,
+        options: HwpLoadOptions
+    ) -> [HwpSection] {
+        var viewTextOptions = options
+        viewTextOptions.recoverPartialContent = false
+        let sortedViewText = viewTextData.sorted { lhs, rhs in
+            sectionIndex(from: lhs.name) < sectionIndex(from: rhs.name)
+        }
+        guard sortedViewText.map(\.name)
+            == (0 ..< expectedSectionCount).map({ "Section\($0)" })
+        else {
+            return []
+        }
+        do {
+            return try sortedViewText.map {
+                try HwpSection.load($0.data, version, options: viewTextOptions)
+            }
+        } catch {
+            return []
+        }
     }
 
     /// "Section12" → 12 (숫자 없으면 Int.max — 뒤로 보냄)

--- a/Sources/CoreHwp/HwpLoadOptions.swift
+++ b/Sources/CoreHwp/HwpLoadOptions.swift
@@ -11,16 +11,32 @@ public struct HwpLoadOptions: Sendable {
     /// 파싱 후 해제되게 한다. 파싱된 typed 필드는 양 모드 동일.
     public var preserveRawPayload: Bool
 
-    public init(readLimits: HwpReadLimits = .default, preserveRawPayload: Bool = true) {
+    /// 손상 문단·구역을 fail-fast 대신 placeholder로 대체해 나머지 본문을
+    /// 살리는 best-effort 복구 여부. 기본 false (기존 fail-fast 시맨틱).
+    /// 복구는 BodyText 한정이다 — ViewText는 구역 하나라도 실패하면 전량
+    /// 폐기해 BodyText로 강등하는 기존 채택 규칙을 유지한다 (#65).
+    /// FileHeader `unsupportedFeature`·자원 한도 2종은 켜져 있어도 전파된다.
+    public var recoverPartialContent: Bool
+
+    public init(
+        readLimits: HwpReadLimits = .default,
+        preserveRawPayload: Bool = true,
+        recoverPartialContent: Bool = false
+    ) {
         self.readLimits = readLimits
         self.preserveRawPayload = preserveRawPayload
+        self.recoverPartialContent = recoverPartialContent
     }
 
     /// 기본 옵션 — 원본 payload를 전부 보존한다 (기존 동작).
     public static let `default` = HwpLoadOptions()
 
-    /// 뷰어 옵션 — 보존용 원본 슬라이스를 비워 상주 메모리를 줄인다.
-    public static let viewer = HwpLoadOptions(preserveRawPayload: false)
+    /// 뷰어 옵션 — 보존용 원본 슬라이스를 비워 상주 메모리를 줄이고,
+    /// 손상 문단·구역은 placeholder로 복구해 나머지 본문을 그린다.
+    public static let viewer = HwpLoadOptions(
+        preserveRawPayload: false,
+        recoverPartialContent: true
+    )
 }
 
 extension HwpLoadOptions {

--- a/Sources/CoreHwp/Models/Section/AGENTS.md
+++ b/Sources/CoreHwp/Models/Section/AGENTS.md
@@ -57,6 +57,42 @@ record는 4-byte 컨트롤 ID로 시작하며,
 - 단락 하위 record는 고정된 순서로 디코딩된다 (header → text → charShape →
   rangeTag → lineSeg → ctrls). 순서를 바꾸지 말 것.
 
+## 부분 복구 placeholder (#65)
+
+`HwpLoadOptions.recoverPartialContent`가 켜지면 손상 문단·구역이 fail-fast
+대신 placeholder로 대체된다 (설계·게이트는 루트 `AGENTS.md` "부분 복구").
+placeholder 생성이 이 폴더에 있으므로 그 형태 계약을 여기 남긴다.
+
+- `HwpParagraph.parseFailurePlaceholder(record:error:)`는 `paraText = nil` +
+  원본 레코드를 `unknownChildren`에 보존 + `parseFailure`에 원인. `paraText`가
+  nil인 이유: 기본 문단은 extended char 2개를 갖는데 ctrlHeader 없이 두면
+  컨트롤 매칭이 어긋나고, nil은 하류 run builder가 이미 빈 문단으로 처리한다.
+- `HwpSection.parseFailurePlaceholder(error:rawPayload:)`는 빈 문서 템플릿 문단
+  (sectionDef+column)을 채워 조판 전제를 지키고 구역 수를 보존한다.
+- **`parseFailure`는 Equatable/Hashable에 참여한다** — placeholder와 진짜 빈
+  문단/구역이 같다고 판정되면 복구 흔적이 비교에서 지워진다. 새 저장 필드지만
+  raw payload 파생이 아니라 로드 사건의 기록이라 legacy 아카이브에서
+  재수화하지 않는다 (`decodeIfPresent ?? nil` — 루트 "Codable 아카이브 호환").
+- 손상 **메모 문단**도 `HwpParagraph.load`의 메모 수집 루프에서 개별
+  placeholder로 대체한다 — 전파시키면 호스트 문단 전체가 placeholder가 되어
+  본문·메모 그룹 경계까지 잃는다.
+
+## `HwpParaText.wcharCount` (#67)
+
+파스 루프가 실제로 소비한 wchar의 **누적 저장값**이다 (컨트롤 문자 = 8 wchar).
+문단당 `reduce` 재계산에서 바뀌었지만 값·공개 API는 동일하다 — `charArray`
+변경 시 `didSet`이 재동기화한다. 파생값이라 **Equatable/Hashable·인코딩 모두에서
+제외**: payload **유무** 파생이라 `HwpChar` 동등성(type/value만)과 어긋날 수
+있고, 빈 템플릿 vs 파싱본의 round-trip 동등성이 이 제외에 기댄다. custom
+Codable은 `rawPayload`/`charArray` 두 키만 인코딩하고 디코더가 재계산한다.
+"파생 필드는 저장보다 재계산" 컨벤션의 예외이므로 되돌리지 말 것 — `HwpChar`가
+문서 전체 문자 수만큼 존재해 문단당 reduce가 반복 비용이라 저장으로 옮겼다.
+
+`HwpTableCellHeader`의 음수 `paragraphCount` 가드도 이때 제거됐다 — 표 셀은
+`UInt16`을 `Int32`로 승격해 읽어 항상 비음수라 도달 불가였다 (리스트/글상자와
+달리 bytes 6-7이 셀 확장 속성이라 읽기 폭을 넓힐 수 없다는 근거가
+`HwpTable.swift` 주석). 되살리지 말 것.
+
 ## 안티 패턴
 
 - 모르는 컨트롤에 대해 `invalidCtrlId`를 throw — `.unknown` 또는
@@ -65,3 +101,6 @@ record는 4-byte 컨트롤 ID로 시작하며,
 - 단락 개수 하드코딩 — 구역(section)의 단락 배열은 가변. index 대신 iterate.
 - `CtrlHeader/` 밖에 컨트롤 로직 추가 — dispatch는 `HwpParagraph`에,
   payload는 여기에.
+- `parseFailure` placeholder 로직을 다른 모델·다른 error로 넓히기 — 복구는
+  문단·구역·메모 문단 한정이고 게이트는 `error.isRecoveryExempt`다 (루트
+  "부분 복구").

--- a/Sources/CoreHwp/Models/Section/AGENTS.md
+++ b/Sources/CoreHwp/Models/Section/AGENTS.md
@@ -76,6 +76,11 @@ placeholder 생성이 이 폴더에 있으므로 그 형태 계약을 여기 남
 - 손상 **메모 문단**도 `HwpParagraph.load`의 메모 수집 루프에서 개별
   placeholder로 대체한다 — 전파시키면 호스트 문단 전체가 placeholder가 되어
   본문·메모 그룹 경계까지 잃는다.
+- **구역의 첫 문단은 복구 대상이 아니다** (#110). sectionDef가 첫 문단에만
+  붙으므로 이를 문단 placeholder로 삼키면 paginator가 구역 경계를 놓쳐 그
+  구역이 앞 구역 지오메트리로 조판된다. `HwpSection.load`가 `paragraphs.isEmpty`
+  일 때 전파해 `HwpFile`이 구역 단위 placeholder로 승격시킨다 — 그 가드를
+  지우면 경계 유실이 재발한다 (루트 "부분 복구").
 
 ## `HwpParaText.wcharCount` (#67)
 

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/Table/HwpTable.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/Table/HwpTable.swift
@@ -101,12 +101,11 @@ extension HwpTable: HwpFromRecordWithVersion {
                 continue
             }
 
+            // 파싱 경로의 paragraphCount는 UInt16을 Int32로 승격해 읽으므로
+            // (아래 `HwpTableCellHeader.init(_:_:)`) 항상 비음수다 — 리스트/글상자와
+            // 달리 표 셀 헤더는 bytes 6-7이 셀 확장 속성(listHeaderWidthRef)이라
+            // Int32로 넓혀 읽을 수 없고, 음수 가드도 도달 불가라 두지 않는다 (#67).
             let cellHeader = try HwpTableCellHeader.load(child)
-            guard cellHeader.paragraphCount >= 0 else {
-                throw HwpError.invalidRecordTree(
-                    reason: "table cell paragraph count is negative: \(cellHeader.paragraphCount)"
-                )
-            }
 
             var paragraphs = [HwpParagraph]()
             for _ in 0 ..< Int(cellHeader.paragraphCount) {

--- a/Sources/CoreHwp/Models/Section/HwpParaText.swift
+++ b/Sources/CoreHwp/Models/Section/HwpParaText.swift
@@ -12,7 +12,16 @@ public struct HwpParaText: HwpFromData {
     @ExcludeEquatable
     public var rawPayload: Data
     /** 문자수만큼의 텍스트 */
-    public var charArray: [HwpChar]
+    public var charArray: [HwpChar] {
+        didSet { wcharCount = Self.wcharCount(of: charArray) }
+    }
+
+    /// 원본 payload의 WCHAR 수 — 컨트롤 문자는 wchar 1 + payload 14바이트
+    /// (= wchar 7)로 총 8 wchar를 차지한다. rawPayload 없이도 계산되므로
+    /// PARA_HEADER charCount 검증에 양 모드 공통으로 쓴다. 파스 루프에서
+    /// 누적하고 charArray 변경 시 didSet으로 재동기화하는 파생 저장값이라
+    /// 아카이브에는 싣지 않는다 (아래 custom Codable).
+    public private(set) var wcharCount: Int
 
     init() {
         rawPayload = Data()
@@ -20,27 +29,40 @@ public struct HwpParaText: HwpFromData {
         let char1 = HwpChar(type: .extended, value: 2)
         let char2 = HwpChar(type: .char, value: 13)
         charArray = [char0, char1, char2]
+        wcharCount = Self.wcharCount(of: charArray)
+    }
+
+    init(rawPayload: Data, charArray: [HwpChar]) {
+        self.rawPayload = rawPayload
+        self.charArray = charArray
+        wcharCount = Self.wcharCount(of: charArray)
     }
 
     init(_ reader: inout DataReader) throws {
         let startOffset = reader.byteOffset
         var array = [HwpChar]()
+        var accumulatedWcharCount = 0
         while !reader.isEOF {
             let char = try reader.read(WCHAR.self)
             switch char {
             case 0, 1, 13:
                 array.append(HwpChar(type: .char, value: char))
+                accumulatedWcharCount += 1
             case 4 ... 9, 19 ... 20:
                 let payload = try reader.readBytes(14)
                 array.append(HwpChar(type: .inline, value: char, payload: payload))
+                accumulatedWcharCount += 8
             case 2 ... 3, 11 ... 12, 14 ... 18, 21 ... 23:
                 let payload = try reader.readBytes(14)
                 array.append(HwpChar(type: .extended, value: char, payload: payload))
+                accumulatedWcharCount += 8
             default:
                 array.append(HwpChar(type: .char, value: char))
+                accumulatedWcharCount += 1
             }
         }
         charArray = array
+        wcharCount = accumulatedWcharCount
         rawPayload = try reader.consumedData(from: startOffset)
     }
 
@@ -53,13 +75,51 @@ public struct HwpParaText: HwpFromData {
         paraText.rawPayload = options.preservedPayload(data)
         return paraText
     }
+
+    static func wcharCount(of charArray: [HwpChar]) -> Int {
+        charArray.reduce(0) { $0 + ($1.payload == nil ? 1 : 8) }
+    }
 }
 
+// MARK: - Equatable/Hashable — 종전 synthesized 시맨틱 유지 (charArray만)
+
+// rawPayload는 @ExcludeEquatable였고, wcharCount는 payload **유무**에서
+// 파생되어 HwpChar 동등성(type/value만 비교)과 어긋날 수 있는 파생값이라
+// 비교에서 제외한다 — 빈 문서 템플릿(payload 없는 extended char)과 파싱본
+// (payload 14 byte)의 round-trip 동등성이 이 시맨틱에 기댄다.
+
 public extension HwpParaText {
-    /// 원본 payload의 WCHAR 수 — 컨트롤 문자는 wchar 1 + payload 14바이트
-    /// (= wchar 7)로 총 8 wchar를 차지한다. rawPayload 없이도 계산되므로
-    /// PARA_HEADER charCount 검증에 양 모드 공통으로 쓴다.
-    var wcharCount: Int {
-        charArray.reduce(0) { $0 + ($1.payload == nil ? 1 : 8) }
+    static func == (lhs: HwpParaText, rhs: HwpParaText) -> Bool {
+        lhs.charArray == rhs.charArray
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(charArray)
+    }
+}
+
+// MARK: - Codable — 종전 synthesized 형상 보존 (wcharCount 파생값 제외)
+
+// (rawPayload 키는 ExcludeEquatable 래퍼 {"wrappedValue": …}로 인코딩)
+
+public extension HwpParaText {
+    private enum CodingKeys: String, CodingKey {
+        case rawPayload, charArray
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            rawPayload: try container.decode(
+                ExcludeEquatable<Data>.self, forKey: .rawPayload
+            ).wrappedValue,
+            charArray: try container.decode([HwpChar].self, forKey: .charArray)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(ExcludeEquatable(wrappedValue: rawPayload), forKey: .rawPayload)
+        try container.encode(charArray, forKey: .charArray)
     }
 }

--- a/Sources/CoreHwp/Models/Section/HwpParagraph.swift
+++ b/Sources/CoreHwp/Models/Section/HwpParagraph.swift
@@ -19,6 +19,11 @@ public struct HwpParagraph: HwpFromRecordWithVersion {
     public var memoParagraphGroups: [[HwpParagraph]]?
     @ExcludeEquatable
     public var unknownChildren: [HwpUnknownRecord]
+    /// `HwpLoadOptions.recoverPartialContent` 복구 모드에서 이 문단이 파싱
+    /// 실패를 placeholder로 대체한 것이면 그 원인 설명. 정상 파싱은 nil.
+    /// 진단 표면이므로 Equatable/Hashable에 참여한다 — placeholder와 진짜
+    /// 빈 문단이 같다고 판정되면 복구 흔적이 비교에서 지워진다.
+    public var parseFailure: String?
 
     public init() {
         paraHeader = HwpParaHeader()
@@ -31,6 +36,7 @@ public struct HwpParagraph: HwpFromRecordWithVersion {
         ctrlHeaderArray = nil
         memoParagraphArray = nil
         memoParagraphGroups = nil
+        parseFailure = nil
     }
 
     /// 새 문서의 첫 문단. 구역/단 정의 컨트롤은 구역의 첫 문단에만 붙는다는
@@ -41,6 +47,19 @@ public struct HwpParagraph: HwpFromRecordWithVersion {
             .section(HwpSectionDef()),
             .column(HwpColumn()),
         ]
+        return paragraph
+    }
+
+    /// 복구 모드에서 파싱에 실패한 문단을 대신하는 placeholder.
+    /// `paraText = nil`인 이유: 기본 문단은 extended char 2개를 갖는데
+    /// ctrlHeaderArray가 없으면 컨트롤 매칭이 어긋난다 — paraText 부재
+    /// 문단은 하류 run builder가 이미 빈 문단으로 처리한다. 원본 레코드는
+    /// `unknownChildren`에 통째로 보존해 진단·재파싱 근거를 남긴다 (#65).
+    static func parseFailurePlaceholder(record: HwpRecord, error: HwpError) -> HwpParagraph {
+        var paragraph = HwpParagraph()
+        paragraph.paraText = nil
+        paragraph.unknownChildren = [HwpUnknownRecord(record)]
+        paragraph.parseFailure = String(describing: error)
         return paragraph
     }
 
@@ -159,7 +178,16 @@ public struct HwpParagraph: HwpFromRecordWithVersion {
                     }
                     current = []
                 } else if child.tagId == HwpSectionTag.paraHeader.rawValue, current != nil {
-                    current?.append(try HwpParagraph.load(child, version))
+                    // 복구 모드에서는 손상 메모 문단도 placeholder로 대체한다 —
+                    // 그대로 전파시키면 호스트 문단 전체가 placeholder가 되어
+                    // 본문 텍스트까지 잃고, 메모별 그룹 경계도 함께 사라진다 (#65).
+                    do {
+                        current?.append(try HwpParagraph.load(child, version))
+                    } catch let error as HwpError
+                        where options.recoverPartialContent && !error.isRecoveryExempt
+                    {
+                        current?.append(.parseFailurePlaceholder(record: child, error: error))
+                    }
                 }
             }
             if let current {

--- a/Sources/CoreHwp/Streams/HwpSection.swift
+++ b/Sources/CoreHwp/Streams/HwpSection.swift
@@ -24,8 +24,15 @@ public struct HwpSection: HwpFromDataWithVersion {
     /// 복구 모드에서 파싱에 실패한 구역을 대신하는 placeholder — 빈 문서
     /// 템플릿 문단(sectionDef + column 컨트롤 포함)을 채워 조판 전제를
     /// 지키고, 구역 수를 보존해 뒤 구역의 자리가 밀리지 않게 한다 (#65).
-    static func parseFailurePlaceholder(error: HwpError) -> HwpSection {
+    /// `rawPayload`에는 실패한 구역 스트림 원본을 실어(보존 모드 한정 —
+    /// caller가 `preservedPayload`로 게이트) 문단 placeholder의
+    /// `unknownChildren` 보존과 대칭인 진단·재파싱 근거를 남긴다.
+    static func parseFailurePlaceholder(
+        error: HwpError,
+        rawPayload: Data = Data()
+    ) -> HwpSection {
         var section = HwpSection()
+        section.rawPayload = rawPayload
         section.parseFailure = String(describing: error)
         return section
     }

--- a/Sources/CoreHwp/Streams/HwpSection.swift
+++ b/Sources/CoreHwp/Streams/HwpSection.swift
@@ -9,11 +9,25 @@ public struct HwpSection: HwpFromDataWithVersion {
     public var rawPayload: Data
     public var paragraph: [HwpParagraph]
     public var unknownRecords: [HwpUnknownRecord]
+    /// `HwpLoadOptions.recoverPartialContent` 복구 모드에서 이 구역이 파싱
+    /// 실패를 placeholder(빈 문서 템플릿 문단)로 대체한 것이면 그 원인 설명.
+    /// 정상 파싱은 nil. 진단 표면이므로 Equatable/Hashable에 참여한다.
+    public var parseFailure: String?
 
     init() {
         rawPayload = Data()
         paragraph = [HwpParagraph.blankDocumentParagraph()]
         unknownRecords = []
+        parseFailure = nil
+    }
+
+    /// 복구 모드에서 파싱에 실패한 구역을 대신하는 placeholder — 빈 문서
+    /// 템플릿 문단(sectionDef + column 컨트롤 포함)을 채워 조판 전제를
+    /// 지키고, 구역 수를 보존해 뒤 구역의 자리가 밀리지 않게 한다 (#65).
+    static func parseFailurePlaceholder(error: HwpError) -> HwpSection {
+        var section = HwpSection()
+        section.parseFailure = String(describing: error)
+        return section
     }
 
     // MARK: loader contract exemption - BodyText section stream must be parsed as one record tree
@@ -27,7 +41,16 @@ public struct HwpSection: HwpFromDataWithVersion {
 
         for record in records.children {
             if record.tagId == HwpSectionTag.paraHeader.rawValue {
-                paragraphs.append(try HwpParagraph.load(record, version))
+                // 복구 모드에서는 손상 문단 하나가 구역 전체(→ 문서 전체)를
+                // 실패시키지 않도록 placeholder로 대체한다. 자원 한도 등
+                // recovery-exempt 오류는 계속 전파한다 (#65).
+                do {
+                    paragraphs.append(try HwpParagraph.load(record, version))
+                } catch let error as HwpError
+                    where reader.options.recoverPartialContent && !error.isRecoveryExempt
+                {
+                    paragraphs.append(.parseFailurePlaceholder(record: record, error: error))
+                }
             } else {
                 unknownRecords.append(HwpUnknownRecord(record))
             }

--- a/Sources/CoreHwp/Streams/HwpSection.swift
+++ b/Sources/CoreHwp/Streams/HwpSection.swift
@@ -51,10 +51,17 @@ public struct HwpSection: HwpFromDataWithVersion {
                 // 복구 모드에서는 손상 문단 하나가 구역 전체(→ 문서 전체)를
                 // 실패시키지 않도록 placeholder로 대체한다. 자원 한도 등
                 // recovery-exempt 오류는 계속 전파한다 (#65).
+                //
+                // 단 구역의 첫 문단은 예외다 — sectionDef는 첫 문단에만 붙으므로
+                // (blankDocumentParagraph 참조) 이를 sectionDef 없는 문단
+                // placeholder로 삼키면 paginator가 구역 경계를 인식하지 못해 그
+                // 구역이 앞 구역의 지오메트리로 조판된다. 첫 문단 손상은 전파해
+                // HwpFile이 구역 단위 placeholder(sectionDef 보존)로 승격시킨다 (#110).
                 do {
                     paragraphs.append(try HwpParagraph.load(record, version))
                 } catch let error as HwpError
-                    where reader.options.recoverPartialContent && !error.isRecoveryExempt
+                    where !paragraphs.isEmpty
+                    && reader.options.recoverPartialContent && !error.isRecoveryExempt
                 {
                     paragraphs.append(.parseFailurePlaceholder(record: record, error: error))
                 }

--- a/Sources/HwpKitCore/AGENTS.md
+++ b/Sources/HwpKitCore/AGENTS.md
@@ -68,6 +68,16 @@ CoreHwp.HwpFile
 공유 흐름 상태 (`contentHeightUsed`·`paragraphAnchorTop`)와 `currentBlocks`
 재작성 적용은 paginator에 남는다.
 
+**부분 복구 placeholder 진단** (#65): `recoverPartialContent`가 남긴 손상
+문단·구역 placeholder를 `unsupportedElements()`에 `kind: .placeholder`로 내보내
+복구가 내용을 조용히 숨기지 않게 한다 (렌더는 placeholder의 빈 텍스트를 그리지
+않으므로 이 보고가 유일한 흔적). 문단·구역 placeholder는 `parseFailure` 필드로
+바로 잡히지만 **메모 placeholder는 호스트 문단이 정상 파싱돼 `parseFailure`로
+안 드러나므로** `collectMemoParseFailures`가 메모 그룹과 컨트롤 안 중첩 문단
+(표 셀·리스트·글상자)까지 재귀로 훑는다 (재귀는 파스 시점 `maxNestingDepth`로
+유한). 복구 자체는 `CoreHwp` 파서에 있다 (루트 `AGENTS.md` "부분 복구") — 여기는
+그 진단 노출만 담당한다.
+
 라인 세그먼트 캐시 (PARA_LINE_SEG)의 `lineLocation`은 페이지 내 절대 y다.
 **실제 줄 전진량 = lineHeight + lineSpacing (per-line 캐시 필드)** — 실측:
 연속 세그먼트의 lineLocation 델타와 일치 (헌법주석 30,345/30,348, noori 전부;

--- a/Sources/HwpKitCore/Layout/HwpPaginator.swift
+++ b/Sources/HwpKitCore/Layout/HwpPaginator.swift
@@ -1425,6 +1425,30 @@ private extension HwpPaginator {
                 hint: "손상 문단 복구 (파싱 실패: \(paragraphFailure))"
             ))
         }
+        collectMemoParseFailures(in: paragraph, page: page)
+    }
+
+    /// 메모 복구 placeholder는 호스트 문단이 정상 파싱되므로 호스트
+    /// `parseFailure`로는 드러나지 않는다 — 메모 그룹과, 컨트롤 안 중첩 문단
+    /// (표 셀·리스트·글상자)이 가진 메모 그룹까지 재귀로 보고한다. 렌더는
+    /// placeholder 메모의 빈 텍스트를 `collectMemos`가 건너뛰므로 이 보고가
+    /// 유일한 흔적이다 (#65). 재귀는 파스 시점 `maxNestingDepth`로 유한하다.
+    private func collectMemoParseFailures(in paragraph: CoreHwp.HwpParagraph, page: Int) {
+        for memoParagraph in (paragraph.memoParagraphGroups ?? []).flatMap({ $0 }) {
+            if let failure = memoParagraph.parseFailure {
+                collectedUnsupported.append(HwpUnsupportedElement(
+                    kind: .placeholder,
+                    page: page,
+                    hint: "손상 메모 문단 복구 (파싱 실패: \(failure))"
+                ))
+            }
+            collectMemoParseFailures(in: memoParagraph, page: page)
+        }
+        for ctrl in paragraph.ctrlHeaderArray ?? [] {
+            for (nested, _) in childParagraphs(of: ctrl) {
+                collectMemoParseFailures(in: nested, page: page)
+            }
+        }
     }
 
     /// 개요(머리 종류 1)/번호(2) 문단 머리의 생성 라벨은 numbering 정의에 있고

--- a/Sources/HwpKitCore/Layout/HwpPaginator.swift
+++ b/Sources/HwpKitCore/Layout/HwpPaginator.swift
@@ -1395,8 +1395,36 @@ private extension HwpPaginator {
         // 번호/개요 마커는 문단 첫 페이지 첫 줄에 속하므로 firstPage로 보고하고,
         // 컨트롤은 현재 배치 페이지 기준으로 보고한다 (#3).
         collectUnsupportedNumberingHeading(from: paragraph, page: firstPage)
+        collectRecoveredParseFailures(from: paragraph, page: firstPage)
         guard let ctrls = paragraph.ctrlHeaderArray else { return }
         walkUnsupported(ctrls: ctrls, page: cachedPages.count + 1)
+    }
+
+    /// recover 모드(`HwpLoadOptions.recoverPartialContent`)가 남긴 placeholder를
+    /// 사용자에게 보이게 한다 — 복구가 내용을 조용히 숨기지 않도록 하는
+    /// 진단 채널이다 (#65). 구역 placeholder는 템플릿 문단만 가지므로 구역의
+    /// 첫 문단 시점에 구역 단위로 한 번 보고한다.
+    private func collectRecoveredParseFailures(
+        from paragraph: CoreHwp.HwpParagraph,
+        page: Int
+    ) {
+        if sections.indices.contains(nextSectionIndex),
+           nextParagraphIndex == 0,
+           let sectionFailure = sections[nextSectionIndex].parseFailure
+        {
+            collectedUnsupported.append(HwpUnsupportedElement(
+                kind: .placeholder,
+                page: page,
+                hint: "손상 구역 복구 (파싱 실패: \(sectionFailure))"
+            ))
+        }
+        if let paragraphFailure = paragraph.parseFailure {
+            collectedUnsupported.append(HwpUnsupportedElement(
+                kind: .placeholder,
+                page: page,
+                hint: "손상 문단 복구 (파싱 실패: \(paragraphFailure))"
+            ))
+        }
     }
 
     /// 개요(머리 종류 1)/번호(2) 문단 머리의 생성 라벨은 numbering 정의에 있고

--- a/Tests/CoreHwpTests/AGENTS.md
+++ b/Tests/CoreHwpTests/AGENTS.md
@@ -130,6 +130,33 @@ payload가 0xFFF 이상이면 size 비트가 level 필드로 넘쳐 헤더가 �
 **한도를 올려 덮지 말 것** — 실측 최대 level은 5이므로 픽스처나 파서 쪽을 먼저
 의심한다.
 
+## 부분 복구 스위트 (#65·#67)
+
+`recoverPartialContent` 복구는 손상 입력이 대상이라 합성 레코드 스트림
+(`SectionRecordBuilder`)으로 검증한다. 계약과 함정은 루트 `AGENTS.md` "부분
+복구"에 있고, 여기 스위트는:
+
+- `Utils/Core/HwpErrorTests.swift`의
+  `testRecoveryExemptSetCoversResourceLimitsAndUnsupportedFeature` — recovery-exempt
+  집합(`isRecoveryExempt`: 자원 한도 2종 + `unsupportedFeature`)을 `HwpError`
+  **케이스 단위로** 고정한다. 새 error 케이스를 추가하면 이 스펙이 분류를
+  강제한다 — **`invalidRecordTree`가 exempt로 새어 들면 여기서 빨개진다**
+  (그 케이스를 비-exempt로 명시 단언).
+- `Stability/Parsing/ControlFallbackErrorSetSpecTests.swift` — 별개 축이다.
+  복구 exempt가 아니라 문단의 `canFallbackToRaw*` 세 판정(표/리스트/도형 컨트롤을
+  `.notImplemented`·other로 raw 보존할지 vs 전파할지)을 error 케이스 단위로
+  잠근다. 이름이 비슷하나 `isRecoveryExempt`와 혼동하지 말 것.
+- `Stability/Paragraphs/ParagraphRecoveryPlaceholderTests.swift` — 문단·구역·
+  메모 placeholder 생성과 `parseFailure` 진단. 복구가 켜져야만 대체되고 꺼진
+  기본 모드는 계속 throw함을 대조군으로 함께 단언한다 (깊이 한도의 "공허하지
+  않음" 증명과 같은 규율).
+- `Stability/Paragraphs/ParaTextWcharCountTests.swift` — didSet 재동기화와
+  round-trip 동등성(wcharCount 비교 제외)을 고정.
+- `Stability/Parsing/SectionNestedAdversarialTests.swift`,
+  `Stability/Paragraphs/ParagraphMemoRecursionTests.swift` — 중첩·메모 복구의
+  적대 입력. 뷰어 진단 노출(`kind: .placeholder`)은 `HwpKitCoreTests`의
+  `HwpPaginatorRecoveryPlaceholderTests`가 본다.
+
 ## 압축 해제 기준선 (#68, #101)
 
 `Streams/Readers/HwpInflateTests.swift`는 두 프로덕션 경로(Apple `Compression`,

--- a/Tests/CoreHwpTests/AGENTS.md
+++ b/Tests/CoreHwpTests/AGENTS.md
@@ -149,7 +149,13 @@ payload가 0xFFF 이상이면 size 비트가 level 필드로 넘쳐 헤더가 �
 - `Stability/Paragraphs/ParagraphRecoveryPlaceholderTests.swift` — 문단·구역·
   메모 placeholder 생성과 `parseFailure` 진단. 복구가 켜져야만 대체되고 꺼진
   기본 모드는 계속 throw함을 대조군으로 함께 단언한다 (깊이 한도의 "공허하지
-  않음" 증명과 같은 규율).
+  않음" 증명과 같은 규율). **첫 문단 손상의 구역 단위 승격**(#110)도 여기서
+  잠그되, 중간 문단 손상이 종전대로 문단 placeholder로 남는 대조군을 짝으로
+  둔다 — 한쪽만 있으면 승격을 전 문단으로 넓힌 구현도 통과한다.
+  **손상 문단을 첫 자리에 두는 합성 스트림은 이제 의미가 다르다**: 문단
+  placeholder 경로를 검증하려면 앞에 정상 문단을 둬야 한다 (이 규칙을 어겨
+  `ControlFallbackErrorSetSpecTests`·ViewText 폐기 테스트가 한 번씩
+  잘못된 이유로 통과할 뻔했다).
 - `Stability/Paragraphs/ParaTextWcharCountTests.swift` — didSet 재동기화와
   round-trip 동등성(wcharCount 비교 제외)을 고정.
 - `Stability/Parsing/SectionNestedAdversarialTests.swift`,

--- a/Tests/CoreHwpTests/AGENTS.md
+++ b/Tests/CoreHwpTests/AGENTS.md
@@ -65,7 +65,7 @@ CoreHwpTests/
 ├── Blank/
 ├── Noori/
 ├── Versions/
-├── DocInfo/{BinData,CharShape}/
+├── DocInfo/{BinData,CharShape,Core,IdMappingRecords,IdMappingShapes,RawRecords,TrackChanges}/
 └── Section/Column/
 ```
 

--- a/Tests/CoreHwpTests/FixtureHarness/Paragraphs/FixtureSectionUnknownRecordManifestTests.swift
+++ b/Tests/CoreHwpTests/FixtureHarness/Paragraphs/FixtureSectionUnknownRecordManifestTests.swift
@@ -72,13 +72,12 @@ private func sectionParagraphHeaderPayload() -> Data {
     return data
 }
 
+/// 레코드 프레이밍은 SectionRecordBuilder가 단일 출처다 — private 사본을
+/// 두지 않는다 (#67, Tests/CoreHwpTests/AGENTS.md "합성 레코드 스트림").
 private func sectionRecordData(tagId: UInt32, level: UInt32, payload: Data) -> Data {
-    var data = sectionLittleEndianData(tagId | (level << 10) | (UInt32(payload.count) << 20))
-    data.append(payload)
-    return data
+    SectionRecordBuilder.record(tagId: tagId, level: level, payload: payload)
 }
 
 private func sectionLittleEndianData(_ value: some FixedWidthInteger) -> Data {
-    var littleEndian = value.littleEndian
-    return withUnsafeBytes(of: &littleEndian) { Data($0) }
+    SectionRecordBuilder.littleEndian(value)
 }

--- a/Tests/CoreHwpTests/LoadOptions/ViewerPayloadDecouplingTests.swift
+++ b/Tests/CoreHwpTests/LoadOptions/ViewerPayloadDecouplingTests.swift
@@ -40,6 +40,37 @@ final class ViewerPayloadDecouplingTests: XCTestCase {
         // 막는다. 픽스처는 늘어나는 방향으로만 움직인다.
         expect(inspectedLeafCount).to(beGreaterThanOrEqualTo(100))
     }
+
+    /// DocInfo 스트림 모델도 같은 walker로 덮는다 — 손 목록
+    /// (`RawPayloadOptOutTests`의 docInfo 최상위 필드 +
+    /// `DocInfoRawRecordViewerOptOutTests`의 raw record 6종)이 못 보는
+    /// DocInfo 하위 모델의 새 `Data` 필드가 게이트를 빠뜨리면 여기서 잡힌다.
+    func testViewerDocInfoModelsDoNotAliasSourceStreamBuffer() throws {
+        let fixtures = try FixtureLoader.loadAll()
+            .filter { $0.manifest.expectedError == nil }
+
+        expect(fixtures).notTo(beEmpty())
+        var inspectedLeafCount = 0
+        for fixture in fixtures {
+            let preserved = try HwpFile(fromPath: fixture.documentURL.path)
+            let source = preserved.docInfo.rawPayload
+            guard !source.isEmpty else { continue }
+            let viewerDocInfo = try HwpDocInfo.load(
+                source,
+                preserved.fileHeader.version,
+                options: .viewer
+            )
+
+            inspectedLeafCount += assertNoDataLeafAliases(
+                source: source,
+                in: viewerDocInfo,
+                path: "\(fixture.manifest.id).docInfo"
+            )
+        }
+        // DocInfo는 구역보다 비어 있지 않은 Data leaf가 적다 (뷰어 모드가
+        // 보존 슬라이스를 비우므로) — 현 픽스처 실측 58, 여유를 두고 40.
+        expect(inspectedLeafCount).to(beGreaterThanOrEqualTo(40))
+    }
 }
 
 /// `value` 안의 모든 비어 있지 않은 `Data` leaf를 재귀 방문해 `source`

--- a/Tests/CoreHwpTests/LoadOptions/ViewerPayloadDecouplingTests.swift
+++ b/Tests/CoreHwpTests/LoadOptions/ViewerPayloadDecouplingTests.swift
@@ -1,0 +1,106 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// 뷰어 모드(`.viewer`)에서 파싱된 구역 모델의 **모든 `Data` leaf**가 압축
+/// 해제 스트림 버퍼 밖(분리 복사 또는 empty)임을 Mirror 기반 재귀 walker로
+/// 단언한다 (#67).
+///
+/// `RawPayloadOptOutTests`는 손으로 유지하는 대표 필드 목록만 보므로, 새
+/// 모델 필드가 `decoupledPayload`/`preservedPayload` 게이트를 빠뜨려도
+/// 잡히지 않는다 — 이 walker가 그 사각을 막는다. 원본 버퍼는 default 모드
+/// 로드가 보존한 `section.rawPayload`(구역 스트림 원본)를 재사용한다.
+final class ViewerPayloadDecouplingTests: XCTestCase {
+    func testViewerSectionModelsDoNotAliasSourceStreamBuffer() throws {
+        let fixtures = try FixtureLoader.loadAll()
+            .filter { $0.manifest.expectedError == nil }
+
+        expect(fixtures).notTo(beEmpty())
+        var inspectedLeafCount = 0
+        for fixture in fixtures {
+            let preserved = try HwpFile(fromPath: fixture.documentURL.path)
+            for (index, section) in preserved.sectionArray.enumerated() {
+                let source = section.rawPayload
+                guard !source.isEmpty else { continue }
+                let viewerSection = try HwpSection.load(
+                    source,
+                    preserved.fileHeader.version,
+                    options: .viewer
+                )
+
+                inspectedLeafCount += assertNoDataLeafAliases(
+                    source: source,
+                    in: viewerSection,
+                    path: "\(fixture.manifest.id).section[\(index)]"
+                )
+            }
+        }
+        // 공허 gate — walker가 아무 leaf도 방문하지 않은 채 초록이 되는 것을
+        // 막는다. 픽스처는 늘어나는 방향으로만 움직인다.
+        expect(inspectedLeafCount).to(beGreaterThanOrEqualTo(100))
+    }
+}
+
+/// `value` 안의 모든 비어 있지 않은 `Data` leaf를 재귀 방문해 `source`
+/// 버퍼와의 겹침을 단언하고, 방문한 leaf 수를 돌려준다.
+private func assertNoDataLeafAliases(source: Data, in value: Any, path: String) -> Int {
+    var inspected = 0
+    walkDataLeaves(of: value, path: path) { leaf, leafPath in
+        inspected += 1
+        expect(aliases(leaf, source: source)).to(
+            beFalse(),
+            description: "\(leafPath) must not alias the decompressed section buffer"
+        )
+    }
+    return inspected
+}
+
+private func walkDataLeaves(
+    of value: Any,
+    path: String,
+    visit: (Data, String) -> Void
+) {
+    if let data = value as? Data {
+        if !data.isEmpty {
+            visit(data, path)
+        }
+        return
+    }
+    // charArray는 문서 전체 문자 수만큼 있다 — Mirror 없이 payload만 본다.
+    if let char = value as? HwpChar {
+        if let payload = char.payload, !payload.isEmpty {
+            visit(payload, "\(path).payload")
+        }
+        return
+    }
+    if let chars = value as? [HwpChar] {
+        for (index, char) in chars.enumerated() {
+            walkDataLeaves(of: char, path: "\(path)[\(index)]", visit: visit)
+        }
+        return
+    }
+    let mirror = Mirror(reflecting: value)
+    if mirror.displayStyle == nil, mirror.children.isEmpty {
+        return
+    }
+    for (index, child) in mirror.children.enumerated() {
+        let label = child.label ?? "[\(index)]"
+        walkDataLeaves(of: child.value, path: "\(path).\(label)", visit: visit)
+    }
+}
+
+private func aliases(_ leaf: Data, source: Data) -> Bool {
+    source.withUnsafeBytes { sourceBuffer -> Bool in
+        guard let sourceBase = sourceBuffer.baseAddress, !sourceBuffer.isEmpty else {
+            return false
+        }
+        return leaf.withUnsafeBytes { leafBuffer -> Bool in
+            guard let leafBase = leafBuffer.baseAddress, !leafBuffer.isEmpty else {
+                return false
+            }
+            return leafBase >= sourceBase
+                && leafBase < sourceBase + sourceBuffer.count
+        }
+    }
+}

--- a/Tests/CoreHwpTests/Stability/LegacyArchiveDecodingTests.swift
+++ b/Tests/CoreHwpTests/Stability/LegacyArchiveDecodingTests.swift
@@ -27,6 +27,40 @@ final class LegacyArchiveDecodingTests: XCTestCase {
         expect(decoded.displaySectionArray.count) == 1
     }
 
+    func testHwpParagraphDecodesLegacyArchiveWithoutParseFailure() throws {
+        let legacy = try legacyJSON(of: HwpParagraph(), removingKey: "parseFailure")
+
+        let decoded = try JSONDecoder().decode(HwpParagraph.self, from: legacy)
+
+        expect(decoded.parseFailure).to(beNil())
+        expect(decoded) == HwpParagraph()
+    }
+
+    func testHwpSectionDecodesLegacyArchiveWithoutParseFailure() throws {
+        let legacy = try legacyJSON(of: HwpSection(), removingKey: "parseFailure")
+
+        let decoded = try JSONDecoder().decode(HwpSection.self, from: legacy)
+
+        expect(decoded.parseFailure).to(beNil())
+        expect(decoded.paragraph.count) == 1
+    }
+
+    func testParseFailurePlaceholderRoundTripsThroughCodable() throws {
+        let placeholder = HwpParagraph.parseFailurePlaceholder(
+            record: HwpRecord(tagId: 66, level: 0, payload: Data([0xAA])),
+            error: .invalidRecordTree(reason: "spec")
+        )
+
+        let decoded = try JSONDecoder().decode(
+            HwpParagraph.self,
+            from: JSONEncoder().encode(placeholder)
+        )
+
+        expect(decoded.parseFailure) == placeholder.parseFailure
+        expect(decoded.paraText).to(beNil())
+        expect(decoded) == placeholder
+    }
+
     func testHwpReadLimitsDecodeLegacyArchiveWithoutAggregateKey() throws {
         let legacy = try legacyJSON(
             of: HwpReadLimits.default, removingKey: "maxAggregateStreamBytes"

--- a/Tests/CoreHwpTests/Stability/Paragraphs/ParaTextWcharCountTests.swift
+++ b/Tests/CoreHwpTests/Stability/Paragraphs/ParaTextWcharCountTests.swift
@@ -1,0 +1,87 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// `HwpParaText.wcharCount` O(1) 저장값 전환 회귀 (#67).
+///
+/// 파스 루프 누적값이 종전 reduce 계산과 같아야 하고, charArray 변경 시
+/// didSet으로 재동기화되며, 인코딩 형상에는 나타나지 않아야 한다
+/// (custom Codable — rawPayload/charArray 두 키만).
+final class ParaTextWcharCountTests: XCTestCase {
+    func testParsedWcharCountMatchesLegacyReduceForMixedControlChars() throws {
+        // 순수 문자 1 + inline 컨트롤(4) 8 + extended 컨트롤(2) 8 = 17 wchar.
+        var payload = wcharLittleEndianData(WCHAR(0xAC00))
+        payload.append(wcharLittleEndianData(WCHAR(4)))
+        payload.append(Data(repeating: 0xAA, count: 14))
+        payload.append(wcharLittleEndianData(WCHAR(2)))
+        payload.append(Data(repeating: 0xBB, count: 14))
+
+        let paraText = try HwpParaText.load(payload)
+
+        expect(paraText.wcharCount) == 17
+        expect(paraText.wcharCount) == legacyReduceWcharCount(paraText.charArray)
+        expect(paraText.charArray.count) == 3
+    }
+
+    func testWcharCountResynchronizesWhenCharArrayIsMutated() throws {
+        var paraText = try HwpParaText.load(wcharLittleEndianData(WCHAR(0xAC00)))
+        expect(paraText.wcharCount) == 1
+
+        paraText.charArray.append(HwpChar(type: .char, value: 65))
+        expect(paraText.wcharCount) == 2
+
+        paraText.charArray.append(
+            HwpChar(type: .inline, value: 4, payload: Data(repeating: 0, count: 14))
+        )
+        expect(paraText.wcharCount) == 10
+
+        paraText.charArray = []
+        expect(paraText.wcharCount) == 0
+    }
+
+    func testEncodedShapeOmitsWcharCountAndRoundTrips() throws {
+        let paraText = try HwpParaText.load(wcharLittleEndianData(WCHAR(0xAC00)))
+
+        let encoded = try JSONEncoder().encode(paraText)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        expect(Array(json.keys).sorted()) == ["charArray", "rawPayload"]
+
+        let decoded = try JSONDecoder().decode(HwpParaText.self, from: encoded)
+        expect(decoded) == paraText
+        expect(decoded.wcharCount) == 1
+    }
+
+    func testDefaultParaTextKeepsBlankDocumentCount() {
+        // 기본 문단(extended 2·2 + char 13, payload 없음)은 종전 계산대로 3.
+        expect(HwpParaText().wcharCount) == 3
+    }
+
+    func testDecodesLegacyArchiveWithoutWcharCountKey() throws {
+        // wcharCount는 파생 저장값이라 인코딩되지 않는다 — 키가 없는 (모든)
+        // 아카이브에서 charArray로부터 재계산된다 (루트 AGENTS.md "Codable
+        // 아카이브 호환").
+        let encoded = try JSONEncoder().encode(HwpParaText())
+        var json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        json.removeValue(forKey: "wcharCount")
+        let legacy = try JSONSerialization.data(withJSONObject: json)
+
+        let decoded = try JSONDecoder().decode(HwpParaText.self, from: legacy)
+
+        expect(decoded.wcharCount) == 3
+        expect(decoded.charArray) == HwpParaText().charArray
+    }
+}
+
+private func legacyReduceWcharCount(_ charArray: [HwpChar]) -> Int {
+    charArray.reduce(0) { $0 + ($1.payload == nil ? 1 : 8) }
+}
+
+private func wcharLittleEndianData(_ value: some FixedWidthInteger) -> Data {
+    var littleEndian = value.littleEndian
+    return withUnsafeBytes(of: &littleEndian) { Data($0) }
+}

--- a/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphMemoRecursionTests.swift
+++ b/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphMemoRecursionTests.swift
@@ -1,0 +1,224 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// 메모(MEMO_LIST 93) 재귀 파싱의 정상 경로·경계·복구 시맨틱 고정 (#67).
+///
+/// 재귀 깊이 자체는 파스 시점 가드(`HwpRecord.parseTreeRecord`의
+/// `maxNestingDepth`, #64)가 상한하고 `RecordDepthLimitTests`가 경계를
+/// 커버한다 — 렌더 측 `HwpPaginator.maximumContainerDepth = 3`은 **배치
+/// 재귀**(컨테이너 중첩)의 별도 한도라 파서 한도와 의미가 다르며, 초과분은
+/// 파싱은 되고 진단(`unsupportedElements`)으로만 보고된다. 여기서는 메모
+/// 그룹 경계와 recover 모드(#65)의 placeholder 대체만 다룬다.
+final class ParagraphMemoRecursionTests: XCTestCase {
+    private let version = HwpVersion(5, 0, 1, 1)
+
+    func testSingleMemoWithMultipleParagraphsKeepsGroupBoundary() throws {
+        let host = memoHostParagraphRecord(children: [
+            HwpRecord(tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()),
+            HwpRecord(tagId: HwpSectionTag.paraLineSeg.rawValue, level: 1, payload: Data()),
+            HwpRecord(tagId: HwpSectionTag.memoList.rawValue, level: 1, payload: Data()),
+            memoParagraphRecord(text: 0xAC00),
+            memoParagraphRecord(text: 0xB098),
+        ])
+
+        let paragraph = try HwpParagraph.load(host, version)
+
+        expect(paragraph.memoParagraphGroups?.count) == 1
+        expect(paragraph.memoParagraphGroups?.first?.count) == 2
+        expect(
+            paragraph.memoParagraphGroups?.first?
+                .map { $0.paraText?.charArray.map(\.value) ?? [] }
+        ) == [[0xAC00], [0xB098]]
+        expect(paragraph.memoParagraphArray?.count) == 2
+        // MEMO_LIST와 그 문단들은 소비된 것으로 처리되어 unknownChildren에
+        // 남지 않는다.
+        expect(paragraph.unknownChildren).to(beEmpty())
+    }
+
+    func testMultipleMemosSplitIntoSeparateGroups() throws {
+        let host = memoHostParagraphRecord(children: [
+            HwpRecord(tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()),
+            HwpRecord(tagId: HwpSectionTag.paraLineSeg.rawValue, level: 1, payload: Data()),
+            HwpRecord(tagId: HwpSectionTag.memoList.rawValue, level: 1, payload: Data()),
+            memoParagraphRecord(text: 0xAC00),
+            HwpRecord(tagId: HwpSectionTag.memoList.rawValue, level: 1, payload: Data()),
+            memoParagraphRecord(text: 0xB098),
+            memoParagraphRecord(text: 0xB2E4),
+        ])
+
+        let paragraph = try HwpParagraph.load(host, version)
+
+        expect(paragraph.memoParagraphGroups?.count) == 2
+        expect(paragraph.memoParagraphGroups?.map(\.count)) == [1, 2]
+        // 평탄 배열은 그룹의 flatMap이다.
+        expect(paragraph.memoParagraphArray?.count) == 3
+    }
+
+    func testMemoListWithoutParagraphsKeepsEmptyGroupAndNilFlatArray() throws {
+        let host = memoHostParagraphRecord(children: [
+            HwpRecord(tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()),
+            HwpRecord(tagId: HwpSectionTag.paraLineSeg.rawValue, level: 1, payload: Data()),
+            HwpRecord(tagId: HwpSectionTag.memoList.rawValue, level: 1, payload: Data()),
+        ])
+
+        let paragraph = try HwpParagraph.load(host, version)
+
+        // 문단 없는 메모: 그룹은 빈 배열 하나, 평탄 배열은 nil — 현행 시맨틱 고정.
+        expect(paragraph.memoParagraphGroups?.count) == 1
+        expect(paragraph.memoParagraphGroups?.first).to(beEmpty())
+        expect(paragraph.memoParagraphArray).to(beNil())
+    }
+
+    func testCorruptMemoParagraphThrowsTypedErrorInDefaultMode() {
+        // default 모드: 손상 메모 문단은 호스트 문단 전체를 실패시킨다.
+        let corruptDefault = memoHostParagraphRecord(children: [
+            HwpRecord(tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()),
+            HwpRecord(tagId: HwpSectionTag.paraLineSeg.rawValue, level: 1, payload: Data()),
+            HwpRecord(tagId: HwpSectionTag.memoList.rawValue, level: 1, payload: Data()),
+            memoParagraphRecord(text: 0xAC00),
+            corruptMemoParagraphRecord(),
+        ])
+
+        expect {
+            _ = try HwpParagraph.load(corruptDefault, self.version)
+        }.to(throwError { error in
+            guard case let HwpError.recordDoesNotExist(tag) = error else {
+                return fail("Expected recordDoesNotExist, got \(error)")
+            }
+            expect(tag) == HwpSectionTag.paraCharShape.rawValue
+        })
+    }
+
+    func testCorruptMemoParagraphBecomesPlaceholderInRecoverMode() throws {
+        // recover 모드: 손상 메모 문단만 placeholder로 바뀌고 그룹 경계·호스트는
+        // 보존된다 (#65).
+        let recoverOptions = HwpLoadOptions(recoverPartialContent: true)
+        let corruptRecover = memoHostParagraphRecord(
+            children: [
+                HwpRecord(
+                    tagId: HwpSectionTag.paraCharShape.rawValue,
+                    level: 1,
+                    payload: Data(),
+                    options: recoverOptions
+                ),
+                HwpRecord(
+                    tagId: HwpSectionTag.paraLineSeg.rawValue,
+                    level: 1,
+                    payload: Data(),
+                    options: recoverOptions
+                ),
+                HwpRecord(
+                    tagId: HwpSectionTag.memoList.rawValue,
+                    level: 1,
+                    payload: Data(),
+                    options: recoverOptions
+                ),
+                memoParagraphRecord(text: 0xAC00, options: recoverOptions),
+                corruptMemoParagraphRecord(options: recoverOptions),
+            ],
+            options: recoverOptions
+        )
+
+        let paragraph = try HwpParagraph.load(corruptRecover, version)
+
+        expect(paragraph.parseFailure).to(beNil())
+        expect(paragraph.memoParagraphGroups?.count) == 1
+        let group = try XCTUnwrap(paragraph.memoParagraphGroups?.first)
+        expect(group.count) == 2
+        expect(group[0].parseFailure).to(beNil())
+        expect(group[0].paraText?.charArray.map(\.value)) == [0xAC00]
+        expect(group[1].parseFailure).to(
+            contain("Record '\(HwpSectionTag.paraCharShape.rawValue)' does not exist")
+        )
+        expect(group[1].paraText).to(beNil())
+        expect(group[1].unknownChildren.count) == 1
+        expect(group[1].unknownChildren.first?.tagId) == HwpSectionTag.paraHeader.rawValue
+    }
+}
+
+private func memoHostParagraphRecord(
+    children: [HwpRecord],
+    options: HwpLoadOptions = .default
+) -> HwpRecord {
+    let record = HwpRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: memoParagraphHeaderPayload(charCount: 0),
+        options: options
+    )
+    record.children = children
+    return record
+}
+
+private func memoParagraphRecord(
+    text: WCHAR,
+    options: HwpLoadOptions = .default
+) -> HwpRecord {
+    let record = HwpRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 1,
+        payload: memoParagraphHeaderPayload(charCount: 1),
+        options: options
+    )
+    record.children = [
+        HwpRecord(
+            tagId: HwpSectionTag.paraText.rawValue,
+            level: 2,
+            payload: memoLittleEndianData(text),
+            options: options
+        ),
+        HwpRecord(
+            tagId: HwpSectionTag.paraCharShape.rawValue,
+            level: 2,
+            payload: Data(),
+            options: options
+        ),
+        HwpRecord(
+            tagId: HwpSectionTag.paraLineSeg.rawValue,
+            level: 2,
+            payload: Data(),
+            options: options
+        ),
+    ]
+    return record
+}
+
+/// 필수 PARA_CHAR_SHAPE가 없는 메모 문단 — recordDoesNotExist를 던진다.
+private func corruptMemoParagraphRecord(options: HwpLoadOptions = .default) -> HwpRecord {
+    let record = HwpRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 1,
+        payload: memoParagraphHeaderPayload(charCount: 0),
+        options: options
+    )
+    record.children = [
+        HwpRecord(
+            tagId: HwpSectionTag.paraLineSeg.rawValue,
+            level: 2,
+            payload: Data(),
+            options: options
+        ),
+    ]
+    return record
+}
+
+private func memoParagraphHeaderPayload(charCount: UInt32) -> Data {
+    var data = Data()
+    data.append(memoLittleEndianData(charCount | 0x8000_0000))
+    data.append(memoLittleEndianData(UInt32(0)))
+    data.append(memoLittleEndianData(UInt16(0)))
+    data.append(memoLittleEndianData(UInt8(0)))
+    data.append(memoLittleEndianData(UInt8(0)))
+    data.append(memoLittleEndianData(UInt16(0)))
+    data.append(memoLittleEndianData(UInt16(0)))
+    data.append(memoLittleEndianData(UInt16(0)))
+    data.append(memoLittleEndianData(UInt32(1)))
+    return data
+}
+
+private func memoLittleEndianData(_ value: some FixedWidthInteger) -> Data {
+    var littleEndian = value.littleEndian
+    return withUnsafeBytes(of: &littleEndian) { Data($0) }
+}

--- a/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphRecoveryPlaceholderTests.swift
+++ b/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphRecoveryPlaceholderTests.swift
@@ -1,0 +1,434 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// `HwpLoadOptions.recoverPartialContent` (#65) — 손상 문단·구역의
+/// placeholder 전환 매트릭스.
+///
+/// default 모드는 기존 fail-fast typed error를 그대로 던지고, recover
+/// 모드는 실패 지점만 placeholder(`parseFailure` + 원본 레코드 보존)로
+/// 바꿔 나머지 본문을 보존해야 한다. 구역 스트림 구조 자체의 손상은
+/// `HwpSection.load`에서 양 모드 모두 throw하고, 구역 단위 복구는
+/// `HwpFile` 조립이 맡는다.
+final class ParagraphRecoveryPlaceholderTests: XCTestCase {
+    private let version = HwpVersion(5, 0, 1, 1)
+    private let recoverOptions = HwpLoadOptions(recoverPartialContent: true)
+
+    // MARK: - 문단 카운트 4종 + 필수 레코드 누락 placeholder 전환 매트릭스
+
+    func testCharShapeCountMismatchBecomesPlaceholderOnlyInRecoverMode() throws {
+        try assertMiddleParagraphRecovery(
+            corrupt: recoveryParagraphData(
+                headerPayload: recoveryParaHeaderPayload(charShapeInfoCount: 2),
+                charShapePayload: recoveryCharShapePairPayload()
+            ),
+            expectedFailure: "paragraph char shape count mismatch"
+        )
+    }
+
+    func testParaTextCountMismatchBecomesPlaceholderOnlyInRecoverMode() throws {
+        try assertMiddleParagraphRecovery(
+            corrupt: recoveryParagraphData(
+                headerPayload: recoveryParaHeaderPayload(charCount: 2),
+                paraTextPayload: recoveryLittleEndianData(WCHAR(0xAC00))
+            ),
+            expectedFailure: "paragraph text count mismatch"
+        )
+    }
+
+    func testLineSegCountMismatchBecomesPlaceholderOnlyInRecoverMode() throws {
+        try assertMiddleParagraphRecovery(
+            corrupt: recoveryParagraphData(
+                headerPayload: recoveryParaHeaderPayload(alignInfoCount: 2),
+                lineSegPayload: recoveryLineSegEntryPayload()
+            ),
+            expectedFailure: "paragraph line segment count mismatch"
+        )
+    }
+
+    func testRangeTagCountMismatchBecomesPlaceholderOnlyInRecoverMode() throws {
+        try assertMiddleParagraphRecovery(
+            corrupt: recoveryParagraphData(
+                headerPayload: recoveryParaHeaderPayload(rangeTagInfoCount: 2),
+                rangeTagPayload: recoveryRangeTagEntryPayload()
+            ),
+            expectedFailure: "paragraph range tag count mismatch"
+        )
+    }
+
+    func testMissingCharShapeBecomesPlaceholderOnlyInRecoverMode() throws {
+        try assertMiddleParagraphRecovery(
+            corrupt: recoveryParagraphData(
+                headerPayload: recoveryParaHeaderPayload(),
+                includeCharShape: false
+            ),
+            expectedFailure: "Record '\(HwpSectionTag.paraCharShape.rawValue)' does not exist",
+            expectedDefaultError: { error in
+                guard case let HwpError.recordDoesNotExist(tag) = error else {
+                    return fail("Expected recordDoesNotExist, got \(error)")
+                }
+                expect(tag) == HwpSectionTag.paraCharShape.rawValue
+            }
+        )
+    }
+
+    // MARK: - 구역 스트림 구조 손상은 HwpSection.load에서 양 모드 모두 throw
+
+    func testSectionStreamStructureCorruptionThrowsInBothModes() {
+        var data = recoveryValidParagraphData(text: 0xAC00)
+        data.append(SectionRecordBuilder.record(tagId: 0x2FE, level: 3, payload: Data([0xAA])))
+
+        for options in [HwpLoadOptions.default, recoverOptions] {
+            expect {
+                _ = try HwpSection.load(data, self.version, options: options)
+            }.to(throwError { error in
+                guard case let HwpError.invalidRecordTree(reason) = error else {
+                    return fail("Expected invalidRecordTree, got \(error)")
+                }
+                expect(reason).to(contain("record level 3 has no parent"))
+            })
+        }
+    }
+
+    // MARK: - HwpFile 조립: 구역 실패는 recover 모드에서 placeholder 구역
+
+    func testCorruptSectionBecomesPlaceholderSectionOnlyInRecoverMode() throws {
+        let corruptSection = SectionRecordBuilder.record(
+            tagId: 0x2FE, level: 2, payload: Data([0xAA])
+        )
+        let sectionDataArray = [recoveryAssemblySectionData(), corruptSection]
+
+        expect {
+            _ = try HwpFile(
+                fileHeader: HwpFileHeader(),
+                docInfoData: recoveryAssemblyDocInfoData(sectionSize: 2),
+                sectionDataArray: sectionDataArray
+            )
+        }.to(throwError { error in
+            guard case let HwpError.invalidRecordTree(reason) = error else {
+                return fail("Expected invalidRecordTree, got \(error)")
+            }
+            expect(reason).to(contain("record level 2 has no parent"))
+        })
+
+        let recovered = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: recoveryAssemblyDocInfoData(sectionSize: 2),
+            sectionDataArray: sectionDataArray,
+            options: recoverOptions
+        )
+
+        expect(recovered.sectionArray.count) == 2
+        expect(recovered.sectionArray[0].parseFailure).to(beNil())
+        expect(recovered.sectionArray[0].paragraph.count) == 1
+        let placeholder = recovered.sectionArray[1]
+        expect(placeholder.parseFailure).to(contain("record level 2 has no parent"))
+        // placeholder 구역은 빈 문서 템플릿 문단으로 조판 전제(sectionDef +
+        // column)를 지킨다 — `HwpSection.init()` 재사용을 고정한다.
+        expect(placeholder.paragraph.count) == 1
+        let templateControls = placeholder.paragraph[0].ctrlHeaderArray
+        expect(templateControls?.count) == 2
+        guard case .section = templateControls?.first else {
+            return fail("Expected placeholder section template to carry sectionDef")
+        }
+        guard case .column = templateControls?.last else {
+            return fail("Expected placeholder section template to carry column")
+        }
+        expect(placeholder.paragraph[0].parseFailure).to(beNil())
+        expect(recovered.displaySectionArray.count) == 2
+    }
+
+    // MARK: - ViewText 정책: recover 모드에서도 전량 폐기 → BodyText 강등
+
+    func testCorruptViewTextIsDiscardedEntirelyEvenInRecoverMode() throws {
+        // 문단 카운트 손상은 recover가 켜져 있으면 placeholder로 "성공" 파싱될
+        // 수 있는 입력이다 — ViewText가 이를 채택하면 그 구역이 백지가 되므로,
+        // ViewText 경로는 복구 없이 기존 전량 폐기를 유지해야 한다 (#65).
+        var corruptHeaderPayload = recoveryParaHeaderPayload(charShapeInfoCount: 2)
+        corruptHeaderPayload.append(recoveryLittleEndianData(UInt16(0)))
+        let corruptParagraphSection = recoveryParagraphData(
+            headerPayload: corruptHeaderPayload,
+            charShapePayload: recoveryCharShapePairPayload()
+        )
+        expect {
+            _ = try HwpSection.load(
+                corruptParagraphSection, HwpVersion(), options: self.recoverOptions
+            )
+        }.notTo(throwError())
+
+        let recovered = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: recoveryAssemblyDocInfoData(sectionSize: 1),
+            sectionDataArray: [recoveryAssemblySectionData()],
+            viewTextData: [(name: "Section0", data: corruptParagraphSection)],
+            options: recoverOptions
+        )
+
+        expect(recovered.viewSectionArray).to(beEmpty())
+        expect(recovered.sectionArray.count) == 1
+        expect(recovered.sectionArray[0].parseFailure).to(beNil())
+        expect(recovered.displaySectionArray) == recovered.sectionArray
+    }
+
+    func testHealthyViewTextIsStillAdoptedInRecoverMode() throws {
+        let recovered = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: recoveryAssemblyDocInfoData(sectionSize: 1),
+            sectionDataArray: [recoveryAssemblySectionData()],
+            viewTextData: [(name: "Section0", data: recoveryAssemblySectionData())],
+            options: recoverOptions
+        )
+
+        expect(recovered.viewSectionArray.count) == 1
+        expect(recovered.displaySectionArray) == recovered.viewSectionArray
+    }
+
+    // MARK: - FileHeader 차단 계열은 recover 모드에서도 계속 throw
+
+    func testExpectedErrorFixturesStillThrowUnsupportedFeatureInRecoverMode() throws {
+        let fixtures = try FixtureLoader.loadAll()
+            .filter { $0.manifest.expectedError != nil }
+
+        expect(fixtures).notTo(beEmpty())
+        for fixture in fixtures {
+            expect {
+                _ = try HwpFile(
+                    fromPath: fixture.documentURL.path,
+                    options: self.recoverOptions
+                )
+            }.to(throwError { error in
+                guard case HwpError.unsupportedFeature = error else {
+                    return fail(
+                        "\(fixture.manifest.id): expected unsupportedFeature, got \(error)"
+                    )
+                }
+            })
+        }
+    }
+
+    // MARK: - 정상 픽스처에서는 placeholder가 절대 생기지 않는다
+
+    func testRecoverModeLeavesHealthyFixturesWithoutAnyPlaceholder() throws {
+        let fixtures = try FixtureLoader.loadAll()
+            .filter { $0.manifest.expectedError == nil }
+
+        expect(fixtures).notTo(beEmpty())
+        for fixture in fixtures {
+            let recovered = try HwpFile(
+                fromPath: fixture.documentURL.path,
+                options: .viewer
+            )
+            for section in recovered.sectionArray + recovered.viewSectionArray {
+                expect(section.parseFailure).to(
+                    beNil(),
+                    description: "\(fixture.manifest.id) section placeholder must not fire"
+                )
+                for paragraph in section.paragraph {
+                    expect(paragraph.parseFailure).to(
+                        beNil(),
+                        description: "\(fixture.manifest.id) paragraph placeholder must not fire"
+                    )
+                    for memoParagraph in paragraph.memoParagraphArray ?? [] {
+                        expect(memoParagraph.parseFailure).to(
+                            beNil(),
+                            description: "\(fixture.manifest.id) memo placeholder must not fire"
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - 공통 단언
+
+private extension ParagraphRecoveryPlaceholderTests {
+    /// 정상 문단("가") + 손상 문단 + 정상 문단("나") 구역 스트림으로,
+    /// default 모드의 typed throw와 recover 모드의 placeholder 대체·이웃
+    /// 보존을 함께 고정한다.
+    func assertMiddleParagraphRecovery(
+        corrupt: Data,
+        expectedFailure: String,
+        expectedDefaultError: ((Error) -> Void)? = nil
+    ) throws {
+        var data = recoveryValidParagraphData(text: 0xAC00)
+        data.append(corrupt)
+        data.append(recoveryValidParagraphData(text: 0xB098))
+
+        expect {
+            _ = try HwpSection.load(data, self.version)
+        }.to(throwError { error in
+            if let expectedDefaultError {
+                expectedDefaultError(error)
+            } else {
+                guard case let HwpError.invalidRecordTree(reason) = error else {
+                    return fail("Expected invalidRecordTree, got \(error)")
+                }
+                expect(reason).to(contain(expectedFailure))
+            }
+        })
+
+        let section = try HwpSection.load(data, version, options: recoverOptions)
+
+        expect(section.parseFailure).to(beNil())
+        expect(section.paragraph.count) == 3
+        expect(section.paragraph[0].parseFailure).to(beNil())
+        expect(section.paragraph[0].paraText?.charArray.map(\.value)) == [0xAC00]
+        expect(section.paragraph[2].parseFailure).to(beNil())
+        expect(section.paragraph[2].paraText?.charArray.map(\.value)) == [0xB098]
+
+        let placeholder = section.paragraph[1]
+        expect(placeholder.parseFailure).to(contain(expectedFailure))
+        expect(placeholder.paraText).to(beNil())
+        expect(placeholder.ctrlHeaderArray).to(beNil())
+        expect(placeholder.unknownChildren.count) == 1
+        expect(placeholder.unknownChildren.first?.tagId) == HwpSectionTag.paraHeader.rawValue
+    }
+}
+
+// MARK: - 합성 스트림 빌더 (프레이밍은 SectionRecordBuilder 위임)
+
+private func recoveryValidParagraphData(text: WCHAR) -> Data {
+    recoveryParagraphData(
+        headerPayload: recoveryParaHeaderPayload(charCount: 1),
+        paraTextPayload: recoveryLittleEndianData(text)
+    )
+}
+
+private func recoveryParagraphData(
+    headerPayload: Data,
+    paraTextPayload: Data? = nil,
+    charShapePayload: Data = Data(),
+    includeCharShape: Bool = true,
+    lineSegPayload: Data = Data(),
+    rangeTagPayload: Data? = nil
+) -> Data {
+    var data = SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: headerPayload
+    )
+    if let paraTextPayload {
+        data.append(SectionRecordBuilder.record(
+            tagId: HwpSectionTag.paraText.rawValue,
+            level: 1,
+            payload: paraTextPayload
+        ))
+    }
+    if includeCharShape {
+        data.append(SectionRecordBuilder.record(
+            tagId: HwpSectionTag.paraCharShape.rawValue,
+            level: 1,
+            payload: charShapePayload
+        ))
+    }
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraLineSeg.rawValue,
+        level: 1,
+        payload: lineSegPayload
+    ))
+    if let rangeTagPayload {
+        data.append(SectionRecordBuilder.record(
+            tagId: HwpSectionTag.paraRangeTag.rawValue,
+            level: 1,
+            payload: rangeTagPayload
+        ))
+    }
+    return data
+}
+
+/// PARA_HEADER payload (5.0.1.1 — isTraceChange 없음, 22 byte).
+/// 카운트 필드 오프셋: charCount 0-3, charShapeInfoCount 12-13,
+/// rangeTagInfoCount 14-15, alignInfoCount 16-17 (`HwpParaHeader` 읽기 순서).
+private func recoveryParaHeaderPayload(
+    charCount: UInt32 = 0,
+    charShapeInfoCount: UInt16 = 0,
+    rangeTagInfoCount: UInt16 = 0,
+    alignInfoCount: UInt16 = 0
+) -> Data {
+    var data = Data()
+    data.append(recoveryLittleEndianData(charCount | 0x8000_0000))
+    data.append(recoveryLittleEndianData(UInt32(0)))
+    data.append(recoveryLittleEndianData(UInt16(0)))
+    data.append(recoveryLittleEndianData(UInt8(0)))
+    data.append(recoveryLittleEndianData(UInt8(0)))
+    data.append(recoveryLittleEndianData(charShapeInfoCount))
+    data.append(recoveryLittleEndianData(rangeTagInfoCount))
+    data.append(recoveryLittleEndianData(alignInfoCount))
+    data.append(recoveryLittleEndianData(UInt32(1)))
+    return data
+}
+
+private func recoveryCharShapePairPayload() -> Data {
+    concatenatedData(
+        recoveryLittleEndianData(UInt32(0)),
+        recoveryLittleEndianData(UInt32(0))
+    )
+}
+
+private func recoveryLineSegEntryPayload() -> Data {
+    var data = Data()
+    data.append(recoveryLittleEndianData(UInt32(0)))
+    data.append(recoveryLittleEndianData(Int32(100)))
+    data.append(recoveryLittleEndianData(Int32(1000)))
+    data.append(recoveryLittleEndianData(Int32(1000)))
+    data.append(recoveryLittleEndianData(Int32(850)))
+    data.append(recoveryLittleEndianData(Int32(600)))
+    data.append(recoveryLittleEndianData(Int32(0)))
+    data.append(recoveryLittleEndianData(Int32(42520)))
+    data.append(recoveryLittleEndianData(UInt32(393_216)))
+    return data
+}
+
+private func recoveryRangeTagEntryPayload() -> Data {
+    concatenatedData(
+        recoveryLittleEndianData(UInt32(1)),
+        recoveryLittleEndianData(UInt32(9)),
+        recoveryLittleEndianData(UInt32(0xABCD))
+    )
+}
+
+// MARK: - HwpFile 조립 최소 입력 (HwpFileHeader() 버전 5.1.0.1 기준)
+
+private func recoveryAssemblyDocInfoData(sectionSize: UInt16) -> Data {
+    concatenatedData(
+        SectionRecordBuilder.record(
+            tagId: HwpDocInfoTag.documentProperties.rawValue,
+            level: 0,
+            payload: concatenatedData(
+                recoveryLittleEndianData(sectionSize),
+                Data(repeating: 0, count: 24)
+            )
+        ),
+        SectionRecordBuilder.record(
+            tagId: HwpDocInfoTag.idMappings.rawValue,
+            level: 0,
+            payload: Array(repeating: Int32(0), count: 18).reduce(into: Data()) { data, count in
+                data.append(recoveryLittleEndianData(count))
+            }
+        )
+    )
+}
+
+/// 5.0.3.2 이상 버전용 24 byte PARA_HEADER를 가진 최소 정상 구역.
+private func recoveryAssemblySectionData() -> Data {
+    var headerPayload = recoveryParaHeaderPayload(charShapeInfoCount: 1)
+    headerPayload.append(recoveryLittleEndianData(UInt16(0)))
+    return concatenatedData(
+        SectionRecordBuilder.record(
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            level: 0,
+            payload: headerPayload
+        ),
+        SectionRecordBuilder.record(
+            tagId: HwpSectionTag.paraCharShape.rawValue,
+            level: 1,
+            payload: recoveryCharShapePairPayload()
+        )
+    )
+}
+
+private func recoveryLittleEndianData(_ value: some FixedWidthInteger) -> Data {
+    SectionRecordBuilder.littleEndian(value)
+}

--- a/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphRecoveryPlaceholderTests.swift
+++ b/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphRecoveryPlaceholderTests.swift
@@ -136,7 +136,19 @@ final class ParagraphRecoveryPlaceholderTests: XCTestCase {
             return fail("Expected placeholder section template to carry column")
         }
         expect(placeholder.paragraph[0].parseFailure).to(beNil())
+        // 보존 모드에서는 실패한 구역 스트림 원본이 placeholder에 남는다 —
+        // 문단 placeholder의 unknownChildren 보존과 대칭인 진단·재파싱 근거.
+        expect(placeholder.rawPayload) == corruptSection
         expect(recovered.displaySectionArray.count) == 2
+
+        let viewerRecovered = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: recoveryAssemblyDocInfoData(sectionSize: 2),
+            sectionDataArray: sectionDataArray,
+            options: .viewer
+        )
+        expect(viewerRecovered.sectionArray[1].parseFailure).notTo(beNil())
+        expect(viewerRecovered.sectionArray[1].rawPayload).to(beEmpty())
     }
 
     // MARK: - ViewText 정책: recover 모드에서도 전량 폐기 → BodyText 강등
@@ -214,6 +226,9 @@ final class ParagraphRecoveryPlaceholderTests: XCTestCase {
             .filter { $0.manifest.expectedError == nil }
 
         expect(fixtures).notTo(beEmpty())
+        // Mirror 재귀로 전수 방문한다 — 최상위·메모뿐 아니라 표 셀·리스트·
+        // 글상자 안 중첩 문단의 메모 placeholder까지 스윕 범위에 넣는다.
+        var visitedParagraphCount = 0
         for fixture in fixtures {
             let recovered = try HwpFile(
                 fromPath: fixture.documentURL.path,
@@ -224,21 +239,36 @@ final class ParagraphRecoveryPlaceholderTests: XCTestCase {
                     beNil(),
                     description: "\(fixture.manifest.id) section placeholder must not fire"
                 )
-                for paragraph in section.paragraph {
-                    expect(paragraph.parseFailure).to(
-                        beNil(),
-                        description: "\(fixture.manifest.id) paragraph placeholder must not fire"
-                    )
-                    for memoParagraph in paragraph.memoParagraphArray ?? [] {
-                        expect(memoParagraph.parseFailure).to(
-                            beNil(),
-                            description: "\(fixture.manifest.id) memo placeholder must not fire"
-                        )
-                    }
-                }
+                visitedParagraphCount += assertNoParseFailure(
+                    in: section, fixture: fixture.manifest.id
+                )
             }
         }
+        // 공허 gate — 중첩 문단이 실제로 방문됐음을 고정한다 (전 픽스처 합계).
+        expect(visitedParagraphCount).to(beGreaterThanOrEqualTo(1000))
     }
+}
+
+/// `value` 안의 모든 `HwpParagraph`(임의 깊이 — 컨트롤·메모 그룹 포함)를
+/// Mirror로 재귀 방문해 parseFailure 부재를 단언하고, 방문 수를 돌려준다.
+private func assertNoParseFailure(in value: Any, fixture fixtureId: String) -> Int {
+    var visited = 0
+    // charArray는 문서 전체 문자 수만큼 있다 — 문단이 나올 수 없으니 걷지 않는다.
+    if value is Data || value is HwpChar || value is [HwpChar] {
+        return 0
+    }
+    if let paragraph = value as? HwpParagraph {
+        visited += 1
+        expect(paragraph.parseFailure).to(
+            beNil(),
+            description: "\(fixtureId) paragraph placeholder must not fire"
+        )
+    }
+    let mirror = Mirror(reflecting: value)
+    for child in mirror.children {
+        visited += assertNoParseFailure(in: child.value, fixture: fixtureId)
+    }
+    return visited
 }
 
 // MARK: - 공통 단언

--- a/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphRecoveryPlaceholderTests.swift
+++ b/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphRecoveryPlaceholderTests.swift
@@ -151,6 +151,80 @@ final class ParagraphRecoveryPlaceholderTests: XCTestCase {
         expect(viewerRecovered.sectionArray[1].rawPayload).to(beEmpty())
     }
 
+    // MARK: - 첫 문단 손상은 구역 단위 placeholder로 승격 (경계 보존)
+
+    func testCorruptFirstParagraphPropagatesInsteadOfPlaceholder() {
+        // 구역의 sectionDef는 첫 문단에만 붙는다. 첫 문단을 문단 placeholder
+        // (sectionDef 없음)로 삼키면 paginator가 구역 경계를 인식하지 못해 그
+        // 구역이 앞 구역의 지오메트리로 조판된다 (#110 P1). 그래서 같은 손상이
+        // 중간 문단이면 삼키지만(assertMiddleParagraphRecovery) 첫 문단이면
+        // recover 모드에서도 전파해, HwpFile이 구역 단위 placeholder로 승격할
+        // 근거를 남긴다.
+        var data = recoveryParagraphData(
+            headerPayload: recoveryParaHeaderPayload(charShapeInfoCount: 2),
+            charShapePayload: recoveryCharShapePairPayload()
+        )
+        data.append(recoveryValidParagraphData(text: 0xB098))
+
+        for options in [HwpLoadOptions.default, recoverOptions] {
+            expect {
+                _ = try HwpSection.load(data, self.version, options: options)
+            }.to(throwError { error in
+                guard case let HwpError.invalidRecordTree(reason) = error else {
+                    return fail("Expected invalidRecordTree, got \(error)")
+                }
+                expect(reason).to(contain("paragraph char shape count mismatch"))
+            })
+        }
+    }
+
+    func testCorruptFirstParagraphEscalatesToSectionPlaceholder() throws {
+        // 조립 경로(HwpFileHeader() = 5.1.0.1, 24바이트 PARA_HEADER)에서 첫 문단이
+        // 손상된 구역은 문단 placeholder가 아니라 구역 단위 placeholder로 승격돼야
+        // 한다 — 빈 문서 템플릿 문단이 sectionDef+column을 담아 구역 경계를 지킨다.
+        var corruptHeader = recoveryParaHeaderPayload(charShapeInfoCount: 2)
+        corruptHeader.append(recoveryLittleEndianData(UInt16(0)))
+        let corruptSection = recoveryParagraphData(
+            headerPayload: corruptHeader,
+            charShapePayload: recoveryCharShapePairPayload()
+        )
+        let sectionDataArray = [recoveryAssemblySectionData(), corruptSection]
+
+        expect {
+            _ = try HwpFile(
+                fileHeader: HwpFileHeader(),
+                docInfoData: recoveryAssemblyDocInfoData(sectionSize: 2),
+                sectionDataArray: sectionDataArray
+            )
+        }.to(throwError { error in
+            guard case let HwpError.invalidRecordTree(reason) = error else {
+                return fail("Expected invalidRecordTree, got \(error)")
+            }
+            expect(reason).to(contain("paragraph char shape count mismatch"))
+        })
+
+        let recovered = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: recoveryAssemblyDocInfoData(sectionSize: 2),
+            sectionDataArray: sectionDataArray,
+            options: recoverOptions
+        )
+
+        expect(recovered.sectionArray.count) == 2
+        let placeholder = recovered.sectionArray[1]
+        expect(placeholder.parseFailure).to(contain("paragraph char shape count mismatch"))
+        expect(placeholder.paragraph.count) == 1
+        let templateControls = placeholder.paragraph[0].ctrlHeaderArray
+        expect(templateControls?.count) == 2
+        guard case .section = templateControls?.first else {
+            return fail("Expected escalated section placeholder to carry sectionDef")
+        }
+        guard case .column = templateControls?.last else {
+            return fail("Expected escalated section placeholder to carry column")
+        }
+        expect(placeholder.rawPayload) == corruptSection
+    }
+
     // MARK: - ViewText 정책: recover 모드에서도 전량 폐기 → BodyText 강등
 
     func testCorruptViewTextIsDiscardedEntirelyEvenInRecoverMode() throws {
@@ -159,10 +233,14 @@ final class ParagraphRecoveryPlaceholderTests: XCTestCase {
         // ViewText 경로는 복구 없이 기존 전량 폐기를 유지해야 한다 (#65).
         var corruptHeaderPayload = recoveryParaHeaderPayload(charShapeInfoCount: 2)
         corruptHeaderPayload.append(recoveryLittleEndianData(UInt16(0)))
-        let corruptParagraphSection = recoveryParagraphData(
+        // 손상을 둘째 문단에 둔다 — 첫 문단 손상은 구역 단위 placeholder로
+        // 승격돼 전파되므로(#110), "placeholder로 성공 파싱되는데도 ViewText는
+        // 폐기한다"는 이 테스트의 전제를 만족하지 못한다.
+        var corruptParagraphSection = recoveryAssemblySectionData()
+        corruptParagraphSection.append(recoveryParagraphData(
             headerPayload: corruptHeaderPayload,
             charShapePayload: recoveryCharShapePairPayload()
-        )
+        ))
         expect {
             _ = try HwpSection.load(
                 corruptParagraphSection, HwpVersion(), options: self.recoverOptions

--- a/Tests/CoreHwpTests/Stability/Parsing/ControlFallbackErrorSetSpecTests.swift
+++ b/Tests/CoreHwpTests/Stability/Parsing/ControlFallbackErrorSetSpecTests.swift
@@ -326,8 +326,9 @@ final class ControlFallbackErrorSetSpecTests: XCTestCase {
             data, version, options: HwpLoadOptions(recoverPartialContent: true)
         )
 
-        expect(section.paragraph.count) == 1
-        let placeholder = section.paragraph[0]
+        expect(section.paragraph.count) == 2
+        expect(section.paragraph[0].parseFailure).to(beNil())
+        let placeholder = section.paragraph[1]
         expect(placeholder.parseFailure).to(contain("HwpParaRangeTag"))
         expect(placeholder.paraText).to(beNil())
         expect(placeholder.unknownChildren.count) == 1
@@ -434,12 +435,31 @@ private func fallbackSpecInvalidUnicodeHyperlinkPayload() -> Data {
 /// 리스트 컨트롤(머리말) 안의 문단이 손상된 PARA_RANGE_TAG(12+1 byte)를 가진
 /// 구역 byte 스트림 — 컨트롤 깊이의 bytesAreNotEOF가 호스트 문단까지
 /// 전파되는 out-of-set 경로를 `HwpSection.load`로 밟는다.
-private func fallbackSpecSectionStreamWithCorruptListControl() -> Data {
+private func fallbackSpecValidParagraphData() -> Data {
     var data = SectionRecordBuilder.record(
         tagId: HwpSectionTag.paraHeader.rawValue,
         level: 0,
         payload: fallbackSpecParagraphHeaderPayload()
     )
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+    ))
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraLineSeg.rawValue, level: 1, payload: Data()
+    ))
+    return data
+}
+
+private func fallbackSpecSectionStreamWithCorruptListControl() -> Data {
+    // 손상 문단 앞에 정상 문단을 둔다 — 구역의 첫 문단이 손상되면 문단
+    // placeholder가 아니라 구역 단위 placeholder로 승격돼 전파되므로(#110),
+    // "컨트롤 오류 → 문단 placeholder" 경로를 고정하려면 첫 자리를 비워야 한다.
+    var data = fallbackSpecValidParagraphData()
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: fallbackSpecParagraphHeaderPayload()
+    ))
     data.append(SectionRecordBuilder.record(
         tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
     ))

--- a/Tests/CoreHwpTests/Stability/Parsing/ControlFallbackErrorSetSpecTests.swift
+++ b/Tests/CoreHwpTests/Stability/Parsing/ControlFallbackErrorSetSpecTests.swift
@@ -1,0 +1,403 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// 컨트롤 폴백 허용 error 집합의 스펙 고정 (#67).
+///
+/// `HwpParagraph.swift`의 `canFallbackToRaw*` 세 판정은 `private extension`이라
+/// 직접 호출로 단언할 수 없다 — 손상 입력의 **동작 경유**로 집합을 고정한다.
+/// 이 표가 스펙이다. 폴백 집합을 바꾸면 이 파일이 함께 바뀌어야 한다 (의도된
+/// 고정).
+///
+/// | 판정 (소비처) | 허용 → 폴백 | 불허 → 전파 (대표) |
+/// |---|---|---|
+/// | `canFallbackToRawControl` (표·하이퍼링크·단·구역정의·쪽번호) |
+///   truncatedData, invalidUnicodeScalar, invalidRawValueForEnum |
+///   recordDoesNotExist, invalidRecordTree, bytesAreNotEOF |
+/// | `canFallbackToRawListControl` (머리말·꼬리말·각주·미주→other) |
+///   위 base + recordDoesNotExist, invalidRecordTree | bytesAreNotEOF |
+/// | `canFallbackToRawGenShapeObject` (gso·공통 도형→notImplemented) |
+///   위 base + invalidRecordTree | recordDoesNotExist, bytesAreNotEOF |
+///
+/// 개별 폴백 사례의 상세 단언은 `Controls/` 스위트가 맡는다
+/// (`TableControlStabilityTests`·`ListControlStabilityTests`·
+/// `ShapeComponentTextBoxStabilityTests`) — 여기서는 집합 경계만 고정한다.
+final class ControlFallbackErrorSetSpecTests: XCTestCase {
+    private let version = HwpVersion(5, 0, 1, 1)
+
+    // MARK: - canFallbackToRawControl (표 계열)
+
+    func testTableTruncatedDataIsInFallbackSet() throws {
+        // truncatedData ∈ canFallbackToRawControl → notImplemented 보존.
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecLittleEndianData(HwpCommonCtrlId.table.rawValue),
+            children: []
+        )
+
+        let paragraph = try HwpParagraph.load(
+            fallbackSpecHostParagraphRecord(control: record),
+            version
+        )
+
+        guard case .notImplemented = paragraph.ctrlHeaderArray?.first else {
+            return fail("Expected truncated table control to fall back to notImplemented")
+        }
+    }
+
+    func testTableRecordDoesNotExistIsOutOfFallbackSet() {
+        // recordDoesNotExist ∉ canFallbackToRawControl → 전파 (표 75 레코드 부재).
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecCommonCtrlPropertyPayload(ctrlId: HwpCommonCtrlId.table.rawValue),
+            children: []
+        )
+
+        expect {
+            _ = try HwpParagraph.load(
+                fallbackSpecHostParagraphRecord(control: record),
+                self.version
+            )
+        }.to(throwError { error in
+            guard case let HwpError.recordDoesNotExist(tag) = error else {
+                return fail("Expected recordDoesNotExist, got \(error)")
+            }
+            expect(tag) == HwpSectionTag.table.rawValue
+        })
+    }
+
+    func testTableNestedBytesAreNotEOFIsOutOfFallbackSet() {
+        // bytesAreNotEOF ∉ canFallbackToRawControl → 셀 문단 깊이에서도 전파.
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecCommonCtrlPropertyPayload(ctrlId: HwpCommonCtrlId.table.rawValue),
+            children: [
+                HwpRecord(
+                    tagId: HwpSectionTag.table.rawValue,
+                    level: 2,
+                    payload: fallbackSpecTablePropertyPayload(rowCount: 1, columnCount: 1)
+                ),
+                HwpRecord(
+                    tagId: HwpSectionTag.listHeader.rawValue,
+                    level: 2,
+                    payload: fallbackSpecTableCellHeaderPayload(paragraphCount: 1)
+                ),
+                fallbackSpecCorruptRangeTagParagraphRecord(level: 2),
+            ]
+        )
+
+        expectFallbackSpecRangeTagBytesAreNotEOF {
+            _ = try HwpParagraph.load(
+                fallbackSpecHostParagraphRecord(control: record),
+                self.version
+            )
+        }
+    }
+
+    // MARK: - canFallbackToRawListControl (머리말 계열)
+
+    func testListControlNegativeCountInvalidRecordTreeIsInFallbackSet() throws {
+        // invalidRecordTree ∈ canFallbackToRawListControl → other 보존.
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecLittleEndianData(HwpOtherCtrlId.header.rawValue),
+            children: [
+                HwpRecord(
+                    tagId: HwpSectionTag.listHeader.rawValue,
+                    level: 2,
+                    payload: fallbackSpecListHeaderPayload(paragraphCount: -1)
+                ),
+            ]
+        )
+
+        let paragraph = try HwpParagraph.load(
+            fallbackSpecHostParagraphRecord(control: record),
+            version
+        )
+
+        guard case let .other(other) = paragraph.ctrlHeaderArray?.first else {
+            return fail("Expected negative-count list control to fall back to other")
+        }
+        expect(other.ctrlId) == .header
+    }
+
+    func testListControlMissingListHeaderRecordDoesNotExistIsInFallbackSet() throws {
+        // recordDoesNotExist ∈ canFallbackToRawListControl → other 보존.
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecLittleEndianData(HwpOtherCtrlId.header.rawValue),
+            children: [
+                HwpRecord(tagId: 0x2FE, level: 2, payload: Data([0xAA])),
+            ]
+        )
+
+        let paragraph = try HwpParagraph.load(
+            fallbackSpecHostParagraphRecord(control: record),
+            version
+        )
+
+        guard case let .other(other) = paragraph.ctrlHeaderArray?.first else {
+            return fail("Expected list control without LIST_HEADER to fall back to other")
+        }
+        expect(other.ctrlId) == .header
+    }
+
+    func testListControlNestedBytesAreNotEOFIsOutOfFallbackSet() {
+        // bytesAreNotEOF ∉ canFallbackToRawListControl → 리스트 문단 깊이에서도 전파.
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecLittleEndianData(HwpOtherCtrlId.header.rawValue),
+            children: [
+                HwpRecord(
+                    tagId: HwpSectionTag.listHeader.rawValue,
+                    level: 2,
+                    payload: fallbackSpecListHeaderPayload(paragraphCount: 1)
+                ),
+                fallbackSpecCorruptRangeTagParagraphRecord(level: 2),
+            ]
+        )
+
+        expectFallbackSpecRangeTagBytesAreNotEOF {
+            _ = try HwpParagraph.load(
+                fallbackSpecHostParagraphRecord(control: record),
+                self.version
+            )
+        }
+    }
+
+    // MARK: - canFallbackToRawGenShapeObject (gso 계열)
+
+    func testGenShapeObjectInvalidRecordTreeIsInFallbackSet() throws {
+        // invalidRecordTree ∈ canFallbackToRawGenShapeObject → notImplemented 보존.
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecCommonCtrlPropertyPayload(
+                ctrlId: HwpCommonCtrlId.genShapeObject.rawValue
+            ),
+            children: [
+                fallbackSpecShapeComponentRecord(children: [
+                    HwpRecord(
+                        tagId: HwpSectionTag.listHeader.rawValue,
+                        level: 3,
+                        payload: fallbackSpecListHeaderPayload(paragraphCount: -1)
+                    ),
+                ]),
+            ]
+        )
+
+        let paragraph = try HwpParagraph.load(
+            fallbackSpecHostParagraphRecord(control: record),
+            version
+        )
+
+        guard case .notImplemented = paragraph.ctrlHeaderArray?.first else {
+            return fail("Expected corrupt text-box gso to fall back to notImplemented")
+        }
+    }
+
+    func testGenShapeObjectRecordDoesNotExistIsOutOfFallbackSet() {
+        // recordDoesNotExist ∉ canFallbackToRawGenShapeObject → 전파
+        // (글상자 문단의 필수 PARA_CHAR_SHAPE 부재).
+        let textBoxParagraph = HwpRecord(
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            level: 3,
+            payload: fallbackSpecParagraphHeaderPayload()
+        )
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecCommonCtrlPropertyPayload(
+                ctrlId: HwpCommonCtrlId.genShapeObject.rawValue
+            ),
+            children: [
+                fallbackSpecShapeComponentRecord(children: [
+                    HwpRecord(
+                        tagId: HwpSectionTag.listHeader.rawValue,
+                        level: 3,
+                        payload: fallbackSpecListHeaderPayload(paragraphCount: 1)
+                    ),
+                    textBoxParagraph,
+                ]),
+            ]
+        )
+
+        expect {
+            _ = try HwpParagraph.load(
+                fallbackSpecHostParagraphRecord(control: record),
+                self.version
+            )
+        }.to(throwError { error in
+            guard case let HwpError.recordDoesNotExist(tag) = error else {
+                return fail("Expected recordDoesNotExist, got \(error)")
+            }
+            expect(tag) == HwpSectionTag.paraCharShape.rawValue
+        })
+    }
+
+    func testGenShapeObjectNestedBytesAreNotEOFIsOutOfFallbackSet() {
+        // bytesAreNotEOF ∉ canFallbackToRawGenShapeObject → 글상자 문단
+        // 깊이에서도 전파.
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecCommonCtrlPropertyPayload(
+                ctrlId: HwpCommonCtrlId.genShapeObject.rawValue
+            ),
+            children: [
+                fallbackSpecShapeComponentRecord(children: [
+                    HwpRecord(
+                        tagId: HwpSectionTag.listHeader.rawValue,
+                        level: 3,
+                        payload: fallbackSpecListHeaderPayload(paragraphCount: 1)
+                    ),
+                    fallbackSpecCorruptRangeTagParagraphRecord(level: 3),
+                ]),
+            ]
+        )
+
+        expectFallbackSpecRangeTagBytesAreNotEOF {
+            _ = try HwpParagraph.load(
+                fallbackSpecHostParagraphRecord(control: record),
+                self.version
+            )
+        }
+    }
+}
+
+// MARK: - 공통 빌더/단언
+
+private func expectFallbackSpecRangeTagBytesAreNotEOF(
+    _ expression: @escaping () throws -> Void
+) {
+    expect {
+        try expression()
+    }.to(throwError { error in
+        guard case let HwpError.bytesAreNotEOF(model, remain) = error else {
+            return fail("Expected bytesAreNotEOF, got \(error)")
+        }
+        expect(String(describing: model)) == "HwpParaRangeTag"
+        expect(remain) == 1
+    })
+}
+
+private func fallbackSpecCtrlRecord(payload: Data, children: [HwpRecord]) -> HwpRecord {
+    let record = HwpRecord(
+        tagId: HwpSectionTag.ctrlHeader.rawValue,
+        level: 1,
+        payload: payload
+    )
+    record.children = children
+    return record
+}
+
+private func fallbackSpecShapeComponentRecord(children: [HwpRecord]) -> HwpRecord {
+    let record = HwpRecord(
+        tagId: HwpSectionTag.shapeComponent.rawValue,
+        level: 2,
+        payload: fallbackSpecLittleEndianData(HwpCommonCtrlId.rectangle.rawValue)
+    )
+    record.children = children
+    return record
+}
+
+private func fallbackSpecHostParagraphRecord(control: HwpRecord) -> HwpRecord {
+    let record = HwpRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: fallbackSpecParagraphHeaderPayload()
+    )
+    record.children = [
+        HwpRecord(tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()),
+        HwpRecord(tagId: HwpSectionTag.paraLineSeg.rawValue, level: 1, payload: Data()),
+        control,
+    ]
+    return record
+}
+
+/// PARA_RANGE_TAG 12 byte 엔트리 뒤 1 byte 꼬리 → `HwpParaRangeTag.loadArray`가
+/// bytesAreNotEOF(remain 1)를 던지는 손상 문단 (레코드 자식으로 중첩시킨다).
+private func fallbackSpecCorruptRangeTagParagraphRecord(level: UInt32) -> HwpRecord {
+    let record = HwpRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: level,
+        payload: fallbackSpecParagraphHeaderPayload()
+    )
+    record.children = [
+        HwpRecord(tagId: HwpSectionTag.paraCharShape.rawValue, level: level + 1, payload: Data()),
+        HwpRecord(
+            tagId: HwpSectionTag.paraRangeTag.rawValue,
+            level: level + 1,
+            payload: concatenatedData(
+                fallbackSpecLittleEndianData(UInt32(1)),
+                fallbackSpecLittleEndianData(UInt32(9)),
+                fallbackSpecLittleEndianData(UInt32(0xABCD)),
+                Data([0xFF])
+            )
+        ),
+    ]
+    return record
+}
+
+private func fallbackSpecParagraphHeaderPayload() -> Data {
+    var data = Data()
+    data.append(fallbackSpecLittleEndianData(UInt32(0x8000_0000)))
+    data.append(fallbackSpecLittleEndianData(UInt32(0)))
+    data.append(fallbackSpecLittleEndianData(UInt16(0)))
+    data.append(fallbackSpecLittleEndianData(UInt8(0)))
+    data.append(fallbackSpecLittleEndianData(UInt8(0)))
+    data.append(fallbackSpecLittleEndianData(UInt16(0)))
+    data.append(fallbackSpecLittleEndianData(UInt16(0)))
+    data.append(fallbackSpecLittleEndianData(UInt16(0)))
+    data.append(fallbackSpecLittleEndianData(UInt32(1)))
+    return data
+}
+
+/// 개체 공통 속성 (표 70) 전체가 유효한 payload — 절단 truncatedData 폴백이
+/// 뒤의 out-of-set 오류를 가리지 않게 한다.
+private func fallbackSpecCommonCtrlPropertyPayload(ctrlId: UInt32) -> Data {
+    var data = Data()
+    data.append(fallbackSpecLittleEndianData(ctrlId))
+    data.append(fallbackSpecLittleEndianData(UInt32(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT(0)))
+    data.append(fallbackSpecLittleEndianData(Int32(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    data.append(fallbackSpecLittleEndianData(UInt32(0)))
+    data.append(fallbackSpecLittleEndianData(Int32(0)))
+    data.append(fallbackSpecLittleEndianData(WORD(0)))
+    return data
+}
+
+private func fallbackSpecTablePropertyPayload(rowCount: UInt16, columnCount: UInt16) -> Data {
+    var data = Data()
+    data.append(fallbackSpecLittleEndianData(UInt32(0)))
+    data.append(fallbackSpecLittleEndianData(rowCount))
+    data.append(fallbackSpecLittleEndianData(columnCount))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    for _ in 0 ..< rowCount {
+        data.append(fallbackSpecLittleEndianData(UInt16(0)))
+    }
+    data.append(fallbackSpecLittleEndianData(UInt16(0)))
+    data.append(fallbackSpecLittleEndianData(UInt16(0)))
+    return data
+}
+
+private func fallbackSpecTableCellHeaderPayload(paragraphCount: UInt16) -> Data {
+    var data = Data()
+    data.append(fallbackSpecLittleEndianData(paragraphCount))
+    data.append(fallbackSpecLittleEndianData(UInt32(0)))
+    data.append(fallbackSpecLittleEndianData(UInt16(0)))
+    data.append(Data(repeating: 0, count: 39))
+    return data
+}
+
+private func fallbackSpecListHeaderPayload(paragraphCount: Int32) -> Data {
+    concatenatedData(
+        fallbackSpecLittleEndianData(paragraphCount),
+        fallbackSpecLittleEndianData(UInt32(0))
+    )
+}
+
+private func fallbackSpecLittleEndianData(_ value: some FixedWidthInteger) -> Data {
+    var littleEndian = value.littleEndian
+    return withUnsafeBytes(of: &littleEndian) { Data($0) }
+}

--- a/Tests/CoreHwpTests/Stability/Parsing/ControlFallbackErrorSetSpecTests.swift
+++ b/Tests/CoreHwpTests/Stability/Parsing/ControlFallbackErrorSetSpecTests.swift
@@ -92,6 +92,42 @@ final class ControlFallbackErrorSetSpecTests: XCTestCase {
         }
     }
 
+    func testColumnUnknownEnumInvalidRawValueForEnumIsInFallbackSet() throws {
+        // invalidRawValueForEnum ∈ canFallbackToRawControl → other 보존 (단 컨트롤).
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecColumnUnknownTypePayload(),
+            children: []
+        )
+
+        let paragraph = try HwpParagraph.load(
+            fallbackSpecHostParagraphRecord(control: record),
+            version
+        )
+
+        guard case let .other(other) = paragraph.ctrlHeaderArray?.first else {
+            return fail("Expected unknown-enum column control to fall back to other")
+        }
+        expect(other.ctrlId) == .column
+    }
+
+    func testHyperlinkInvalidUnicodeScalarIsInFallbackSet() throws {
+        // invalidUnicodeScalar ∈ canFallbackToRawControl → field 보존 (하이퍼링크).
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecInvalidUnicodeHyperlinkPayload(),
+            children: []
+        )
+
+        let paragraph = try HwpParagraph.load(
+            fallbackSpecHostParagraphRecord(control: record),
+            version
+        )
+
+        guard case let .field(field) = paragraph.ctrlHeaderArray?.first else {
+            return fail("Expected invalid-unicode hyperlink to fall back to field")
+        }
+        expect(field.ctrlId) == .hyperLink
+    }
+
     // MARK: - canFallbackToRawListControl (머리말 계열)
 
     func testListControlNegativeCountInvalidRecordTreeIsInFallbackSet() throws {
@@ -252,6 +288,51 @@ final class ControlFallbackErrorSetSpecTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - recover 모드 병행 (#65 상호작용, 이슈 #67 양 모드 병행 채택)
+
+    func testInSetFallbackStaysControlGranularInRecoverMode() throws {
+        // recover 모드에서도 in-set 폴백은 컨트롤 granular로 유지된다 —
+        // 문단 placeholder로 승격되지 않고 호스트 parseFailure도 nil이다.
+        let recoverOptions = HwpLoadOptions(recoverPartialContent: true)
+        let record = fallbackSpecCtrlRecord(
+            payload: fallbackSpecLittleEndianData(HwpCommonCtrlId.table.rawValue),
+            children: [],
+            options: recoverOptions
+        )
+
+        let paragraph = try HwpParagraph.load(
+            fallbackSpecHostParagraphRecord(control: record, options: recoverOptions),
+            version
+        )
+
+        expect(paragraph.parseFailure).to(beNil())
+        guard case .notImplemented = paragraph.ctrlHeaderArray?.first else {
+            return fail("Expected recover-mode truncated table to stay notImplemented")
+        }
+    }
+
+    func testOutOfSetControlErrorBecomesParagraphPlaceholderThroughSectionRecovery() throws {
+        // out-of-set 오류(bytesAreNotEOF)는 recover 모드의 HwpSection 경유에서
+        // 호스트 문단 placeholder로 전환된다 — 컨트롤 손상 → 문단 placeholder
+        // 전환 경로의 스펙 고정. default 모드는 종전대로 typed throw.
+        let data = fallbackSpecSectionStreamWithCorruptListControl()
+
+        expectFallbackSpecRangeTagBytesAreNotEOF {
+            _ = try HwpSection.load(data, self.version)
+        }
+
+        let section = try HwpSection.load(
+            data, version, options: HwpLoadOptions(recoverPartialContent: true)
+        )
+
+        expect(section.paragraph.count) == 1
+        let placeholder = section.paragraph[0]
+        expect(placeholder.parseFailure).to(contain("HwpParaRangeTag"))
+        expect(placeholder.paraText).to(beNil())
+        expect(placeholder.unknownChildren.count) == 1
+        expect(placeholder.unknownChildren.first?.tagId) == HwpSectionTag.paraHeader.rawValue
+    }
 }
 
 // MARK: - 공통 빌더/단언
@@ -270,11 +351,16 @@ private func expectFallbackSpecRangeTagBytesAreNotEOF(
     })
 }
 
-private func fallbackSpecCtrlRecord(payload: Data, children: [HwpRecord]) -> HwpRecord {
+private func fallbackSpecCtrlRecord(
+    payload: Data,
+    children: [HwpRecord],
+    options: HwpLoadOptions = .default
+) -> HwpRecord {
     let record = HwpRecord(
         tagId: HwpSectionTag.ctrlHeader.rawValue,
         level: 1,
-        payload: payload
+        payload: payload,
+        options: options
     )
     record.children = children
     return record
@@ -290,18 +376,105 @@ private func fallbackSpecShapeComponentRecord(children: [HwpRecord]) -> HwpRecor
     return record
 }
 
-private func fallbackSpecHostParagraphRecord(control: HwpRecord) -> HwpRecord {
+private func fallbackSpecHostParagraphRecord(
+    control: HwpRecord,
+    options: HwpLoadOptions = .default
+) -> HwpRecord {
     let record = HwpRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: fallbackSpecParagraphHeaderPayload(),
+        options: options
+    )
+    record.children = [
+        HwpRecord(
+            tagId: HwpSectionTag.paraCharShape.rawValue,
+            level: 1,
+            payload: Data(),
+            options: options
+        ),
+        HwpRecord(
+            tagId: HwpSectionTag.paraLineSeg.rawValue,
+            level: 1,
+            payload: Data(),
+            options: options
+        ),
+        control,
+    ]
+    return record
+}
+
+/// 단 컨트롤 payload의 columnType enum에 정의 밖 값(3)을 심는다 —
+/// `HwpColumn.load`가 invalidRawValueForEnum(HwpColumnType)을 던진다.
+private func fallbackSpecColumnUnknownTypePayload() -> Data {
+    var data = Data()
+    data.append(fallbackSpecLittleEndianData(HwpOtherCtrlId.column.rawValue))
+    data.append(fallbackSpecLittleEndianData(UInt16(3)))
+    data.append(fallbackSpecLittleEndianData(HWPUNIT16(0)))
+    data.append(fallbackSpecLittleEndianData(UInt16(0)))
+    data.append(fallbackSpecLittleEndianData(UInt8(0)))
+    data.append(fallbackSpecLittleEndianData(UInt8(0)))
+    data.append(fallbackSpecLittleEndianData(COLORREF(0)))
+    return data
+}
+
+/// URL 문자열에 unpaired high surrogate(0xD800)를 심은 하이퍼링크 payload —
+/// `HwpHyperlink.load`가 invalidUnicodeScalar를 던진다.
+private func fallbackSpecInvalidUnicodeHyperlinkPayload() -> Data {
+    var data = Data()
+    data.append(fallbackSpecLittleEndianData(HwpFieldCtrlId.hyperLink.rawValue))
+    data.append(fallbackSpecLittleEndianData(UInt32(0)))
+    data.append(fallbackSpecLittleEndianData(BYTE(0xFF)))
+    data.append(fallbackSpecLittleEndianData(WORD(2)))
+    data.append(fallbackSpecLittleEndianData(WCHAR(0x0041)))
+    data.append(fallbackSpecLittleEndianData(WCHAR(0xD800)))
+    return data
+}
+
+/// 리스트 컨트롤(머리말) 안의 문단이 손상된 PARA_RANGE_TAG(12+1 byte)를 가진
+/// 구역 byte 스트림 — 컨트롤 깊이의 bytesAreNotEOF가 호스트 문단까지
+/// 전파되는 out-of-set 경로를 `HwpSection.load`로 밟는다.
+private func fallbackSpecSectionStreamWithCorruptListControl() -> Data {
+    var data = SectionRecordBuilder.record(
         tagId: HwpSectionTag.paraHeader.rawValue,
         level: 0,
         payload: fallbackSpecParagraphHeaderPayload()
     )
-    record.children = [
-        HwpRecord(tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()),
-        HwpRecord(tagId: HwpSectionTag.paraLineSeg.rawValue, level: 1, payload: Data()),
-        control,
-    ]
-    return record
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+    ))
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraLineSeg.rawValue, level: 1, payload: Data()
+    ))
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.ctrlHeader.rawValue,
+        level: 1,
+        payload: fallbackSpecLittleEndianData(HwpOtherCtrlId.header.rawValue)
+    ))
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.listHeader.rawValue,
+        level: 2,
+        payload: fallbackSpecListHeaderPayload(paragraphCount: 1)
+    ))
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 2,
+        payload: fallbackSpecParagraphHeaderPayload()
+    ))
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: 3, payload: Data()
+    ))
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraRangeTag.rawValue,
+        level: 3,
+        payload: concatenatedData(
+            fallbackSpecLittleEndianData(UInt32(1)),
+            fallbackSpecLittleEndianData(UInt32(9)),
+            fallbackSpecLittleEndianData(UInt32(0xABCD)),
+            Data([0xFF])
+        )
+    ))
+    return data
 }
 
 /// PARA_RANGE_TAG 12 byte 엔트리 뒤 1 byte 꼬리 → `HwpParaRangeTag.loadArray`가

--- a/Tests/CoreHwpTests/Stability/Parsing/SectionNestedAdversarialTests.swift
+++ b/Tests/CoreHwpTests/Stability/Parsing/SectionNestedAdversarialTests.swift
@@ -1,0 +1,121 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// 섹션 byte 스트림의 **중첩 위치** 레벨/확장 크기 조작이 public 진입점
+/// `HwpSection.load`를 통과하며 typed error로 전파됨을 고정한다 (#67).
+///
+/// 루트 수준의 같은 조작은 `RecordParserStabilityTests`가 커버한다 — 여기의
+/// 목적은 정상 레코드 뒤 중첩 위치에서의 전파 경로와, 구역 스트림 구조
+/// 손상이 recover 모드(`.viewer`)에서도 똑같이 throw된다는 시맨틱이다
+/// (구역 단위 복구는 `HwpFile` 조립의 몫이다, #65).
+final class SectionNestedAdversarialTests: XCTestCase {
+    private let version = HwpVersion(5, 0, 1, 1)
+    private let bothModes = [HwpLoadOptions.default, .viewer]
+
+    func testNestedLevelJumpThrowsTypedErrorThroughSectionLoad() {
+        // paraHeader(0) → charShape(1) 뒤 level 3: 스택 [root, para, charShape]
+        // 밖의 점프라 부모가 없다.
+        var data = nestedAdversarialValidParagraphData()
+        data.append(SectionRecordBuilder.record(tagId: 0x2FE, level: 3, payload: Data([0xAA])))
+
+        for options in bothModes {
+            expect {
+                _ = try HwpSection.load(data, self.version, options: options)
+            }.to(throwError { error in
+                guard case let HwpError.invalidRecordTree(reason) = error else {
+                    return fail("Expected invalidRecordTree, got \(error)")
+                }
+                expect(reason).to(contain("record level 3 has no parent"))
+            })
+        }
+    }
+
+    func testLevelRetreatOrphanChildThrowsTypedErrorThroughSectionLoad() {
+        // level 1까지 갔다가 level 0으로 후퇴하면 스택이 [root, 0x2FE]로
+        // 잘린다 — 그 뒤의 level 2는 이전 깊이의 고아 자식이라 부모가 없다.
+        var data = nestedAdversarialValidParagraphData()
+        data.append(SectionRecordBuilder.record(tagId: 0x2FE, level: 0, payload: Data([0xBB])))
+        data.append(SectionRecordBuilder.record(tagId: 0x2FD, level: 2, payload: Data([0xCC])))
+
+        for options in bothModes {
+            expect {
+                _ = try HwpSection.load(data, self.version, options: options)
+            }.to(throwError { error in
+                guard case let HwpError.invalidRecordTree(reason) = error else {
+                    return fail("Expected invalidRecordTree, got \(error)")
+                }
+                expect(reason).to(contain("record level 2 has no parent"))
+            })
+        }
+    }
+
+    func testNestedOversizedExtendedRecordThrowsTypedErrorWithoutAllocation() {
+        // 중첩 위치의 0xFFF 확장 크기 + UInt32.max 선언 — 무할당 typed 거부가
+        // 정상 레코드 뒤에서도 유지되는지 (회귀 보험).
+        var data = nestedAdversarialValidParagraphData()
+        data.append(SectionRecordBuilder.header(tagId: 0x2FE, level: 1, size: 0xFFF))
+        data.append(SectionRecordBuilder.littleEndian(UInt32.max))
+        data.append(0xAA)
+
+        for options in bothModes {
+            expect {
+                _ = try HwpSection.load(data, self.version, options: options)
+            }.to(throwError { error in
+                guard case let HwpError.truncatedData(expected, actual) = error else {
+                    return fail("Expected truncatedData, got \(error)")
+                }
+                expect(expected) == Int(UInt32.max)
+                expect(actual) == 1
+            })
+        }
+    }
+
+    func testNestedTruncatedExtendedSizeWordThrowsTypedErrorThroughSectionLoad() {
+        // 0xFFF sentinel 뒤 실제 크기 UInt32가 잘린 스트림 꼬리.
+        var data = nestedAdversarialValidParagraphData()
+        data.append(SectionRecordBuilder.header(tagId: 0x2FE, level: 1, size: 0xFFF))
+        data.append(contentsOf: [0x01, 0x02])
+
+        for options in bothModes {
+            expect {
+                _ = try HwpSection.load(data, self.version, options: options)
+            }.to(throwError { error in
+                guard case let HwpError.truncatedData(expected, actual) = error else {
+                    return fail("Expected truncatedData, got \(error)")
+                }
+                expect(expected) == 4
+                expect(actual) == 2
+            })
+        }
+    }
+}
+
+private func nestedAdversarialValidParagraphData() -> Data {
+    var data = SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: nestedAdversarialParaHeaderPayload()
+    )
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraCharShape.rawValue,
+        level: 1,
+        payload: Data()
+    ))
+    return data
+}
+
+private func nestedAdversarialParaHeaderPayload() -> Data {
+    var data = Data()
+    data.append(SectionRecordBuilder.littleEndian(UInt32(0x8000_0000)))
+    data.append(SectionRecordBuilder.littleEndian(UInt32(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt16(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt8(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt8(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt16(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt16(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt16(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt32(1)))
+    return data
+}

--- a/Tests/CoreHwpTests/Streams/Readers/StreamDecompressionStabilityTests.swift
+++ b/Tests/CoreHwpTests/Streams/Readers/StreamDecompressionStabilityTests.swift
@@ -82,6 +82,42 @@ final class StreamDecompressionStabilityTests: XCTestCase {
         expect(hwp.displaySectionArray.count) == hwp.sectionArray.count
     }
 
+    /// 거부 측 경계 (#67): 실제 OLE의 ViewText storage에 기대 자식 수가
+    /// 어긋나면 **압축 해제 전에** typed invalidRecordTree로 거부된다 —
+    /// 초과분을 잘라 내면 손상/stale ViewText가 유효한 BodyText를 대체하므로
+    /// (`StreamReader.getOptionalNamedDataFromStorage`의 R69 #2 검증). 일치
+    /// 기대치는 통과해 경계 검증이 공허하지 않음을 함께 고정한다.
+    func testViewTextStorageChildCountMismatchIsRejectedBeforeDecompression() throws {
+        let url = hwpURL(#file, "track-changes")
+        let hwp = try HwpFile(fromPath: url.path)
+        let sectionCount = hwp.sectionArray.count
+        let isCompressed = hwp.fileHeader.fileProperty.isCompressed
+        let ole = try OLEFile(url.path)
+        let reader = StreamReader(
+            ole,
+            try StreamReader.rootStreams(from: ole.root.children)
+        )
+
+        for wrongCount in [sectionCount - 1, sectionCount + 1] {
+            expect {
+                _ = try reader.getOptionalNamedDataFromStorage(
+                    .viewText, isCompressed, expectedChildCount: wrongCount
+                )
+            }.to(throwError { error in
+                guard case let HwpError.invalidRecordTree(reason) = error else {
+                    return fail("Expected invalidRecordTree, got \(error)")
+                }
+                expect(reason).to(contain("ViewText child count"))
+                expect(reason).to(contain("!= \(wrongCount)"))
+            })
+        }
+
+        let adopted = try reader.getOptionalNamedDataFromStorage(
+            .viewText, isCompressed, expectedChildCount: sectionCount
+        )
+        expect(adopted.count) == sectionCount
+    }
+
     func testReadLimitsRejectNonPositiveValuesWithTypedError() {
         let cases = [
             HwpReadLimits(maxCompressedStreamBytes: 0),

--- a/Tests/CoreHwpTests/Utils/Core/HwpErrorTests.swift
+++ b/Tests/CoreHwpTests/Utils/Core/HwpErrorTests.swift
@@ -173,6 +173,33 @@ class HwpErrorTests: XCTestCase {
 
         expect(error.localizedDescription) == error.description
     }
+
+    func testRecoveryExemptSetCoversResourceLimitsAndUnsupportedFeature() {
+        // recover 모드(#65)에서도 전파되어야 하는 오류 집합 — placeholder로
+        // 삼키면 자원 한도가 무력화되거나 미지원 문서가 빈 문서로 열린다.
+        let exempt: [HwpError] = [
+            .streamSizeLimitExceeded(name: .bodyText, limit: 1, actual: 2),
+            .aggregateStreamSizeLimitExceeded(name: .bodyText, limit: 1, actual: 2),
+            .unsupportedFeature(.encryptedDocument),
+        ]
+        for error in exempt {
+            expect(error.isRecoveryExempt).to(
+                beTrue(), description: "\(error) must stay recovery-exempt"
+            )
+        }
+
+        let recoverable: [HwpError] = [
+            .invalidRecordTree(reason: "spec"),
+            .recordDoesNotExist(tag: 68),
+            .truncatedData(expected: 4, actual: 1),
+            .bytesAreNotEOF(modelName: "HwpParaRangeTag", remain: 1),
+        ]
+        for error in recoverable {
+            expect(error.isRecoveryExempt).to(
+                beFalse(), description: "\(error) must be recoverable"
+            )
+        }
+    }
 }
 
 private func assertHwpError(_ error: Error) {

--- a/Tests/HwpKitCoreTests/HwpPaginatorRecoveryPlaceholderTests.swift
+++ b/Tests/HwpKitCoreTests/HwpPaginatorRecoveryPlaceholderTests.swift
@@ -1,0 +1,78 @@
+@testable import CoreHwp
+import Foundation
+@testable import HwpKitCore
+import Nimble
+import XCTest
+
+#if canImport(CoreText)
+    /// recover 모드(#65)가 남긴 placeholder 구역·문단의 하류(조판) 안전성과
+    /// `unsupportedElements` 진단 노출을 고정한다.
+    final class HwpPaginatorRecoveryPlaceholderTests: XCTestCase {
+        func testPlaceholderSectionPaginatesAndReportsUnsupportedElement() async throws {
+            let placeholder = CoreHwp.HwpSection.parseFailurePlaceholder(
+                error: .invalidRecordTree(reason: "record level 2 has no parent")
+            )
+            let paginator = HwpPaginator(
+                sections: [CoreHwp.HwpFile().sectionArray[0], placeholder],
+                index: HwpIndex(from: CoreHwp.HwpFile()),
+                fontResolver: .testDeterministic
+            )
+
+            var pageIndex = 0
+            while try await paginator.page(at: pageIndex) != nil {
+                pageIndex += 1
+            }
+            let unsupported = await paginator.unsupportedElements()
+
+            expect(pageIndex) >= 1
+            let sectionHints = unsupported.filter { $0.hint.contains("손상 구역 복구") }
+            expect(sectionHints.count) == 1
+            expect(sectionHints.first?.kind) == .placeholder
+            expect(sectionHints.first?.hint).to(contain("record level 2 has no parent"))
+        }
+
+        func testPlaceholderParagraphPaginatesAndReportsUnsupportedElement() async throws {
+            var section = CoreHwp.HwpFile().sectionArray[0]
+            section.paragraph.append(CoreHwp.HwpParagraph.parseFailurePlaceholder(
+                record: HwpRecord(tagId: 66, level: 0, payload: Data([0xAA])),
+                error: .invalidRecordTree(reason: "paragraph char shape count mismatch")
+            ))
+            let paginator = HwpPaginator(
+                sections: [section],
+                index: HwpIndex(from: CoreHwp.HwpFile()),
+                fontResolver: .testDeterministic
+            )
+
+            var pageIndex = 0
+            while try await paginator.page(at: pageIndex) != nil {
+                pageIndex += 1
+            }
+            let unsupported = await paginator.unsupportedElements()
+
+            expect(pageIndex) >= 1
+            let paragraphHints = unsupported.filter { $0.hint.contains("손상 문단 복구") }
+            expect(paragraphHints.count) == 1
+            expect(paragraphHints.first?.kind) == .placeholder
+            expect(paragraphHints.first?.hint).to(
+                contain("paragraph char shape count mismatch")
+            )
+        }
+
+        func testHealthySectionsReportNoRecoveryPlaceholders() async throws {
+            let file = CoreHwp.HwpFile()
+            let paginator = HwpPaginator(
+                sections: file.sectionArray,
+                index: HwpIndex(from: file),
+                fontResolver: .testDeterministic
+            )
+
+            var pageIndex = 0
+            while try await paginator.page(at: pageIndex) != nil {
+                pageIndex += 1
+            }
+            let unsupported = await paginator.unsupportedElements()
+
+            expect(unsupported.filter { $0.hint.contains("복구") }).to(beEmpty())
+        }
+    }
+#endif

--- a/Tests/HwpKitCoreTests/HwpPaginatorRecoveryPlaceholderTests.swift
+++ b/Tests/HwpKitCoreTests/HwpPaginatorRecoveryPlaceholderTests.swift
@@ -58,6 +58,37 @@ import XCTest
             )
         }
 
+        func testMemoPlaceholderReportsUnsupportedElement() async throws {
+            // 메모 복구 placeholder는 호스트 문단이 정상 파싱되므로 호스트
+            // parseFailure로 드러나지 않고, 렌더의 collectMemos는 빈 텍스트를
+            // 건너뛴다 — 진단 채널 보고가 유일한 흔적이다 (#65).
+            var section = CoreHwp.HwpFile().sectionArray[0]
+            var host = section.paragraph[0]
+            host.memoParagraphGroups = [[
+                CoreHwp.HwpParagraph.parseFailurePlaceholder(
+                    record: HwpRecord(tagId: 66, level: 1, payload: Data()),
+                    error: .invalidRecordTree(reason: "paragraph char shape count mismatch")
+                ),
+            ]]
+            section.paragraph[0] = host
+            let paginator = HwpPaginator(
+                sections: [section],
+                index: HwpIndex(from: CoreHwp.HwpFile()),
+                fontResolver: .testDeterministic
+            )
+
+            var pageIndex = 0
+            while try await paginator.page(at: pageIndex) != nil {
+                pageIndex += 1
+            }
+            let unsupported = await paginator.unsupportedElements()
+
+            let memoHints = unsupported.filter { $0.hint.contains("손상 메모 문단 복구") }
+            expect(memoHints.count) == 1
+            expect(memoHints.first?.kind) == .placeholder
+            expect(memoHints.first?.hint).to(contain("paragraph char shape count mismatch"))
+        }
+
         func testPlaceholderOnlySectionWithoutSectionDefUsesDefaultGeometry() async throws {
             // 구역의 유일한 문단이 placeholder면 sectionDef/column 컨트롤이
             // 없다 — 조판은 기본 지오메트리 폴백(`?? HwpSectionDef()`)으로

--- a/Tests/HwpKitCoreTests/HwpPaginatorRecoveryPlaceholderTests.swift
+++ b/Tests/HwpKitCoreTests/HwpPaginatorRecoveryPlaceholderTests.swift
@@ -58,6 +58,28 @@ import XCTest
             )
         }
 
+        func testPlaceholderOnlySectionWithoutSectionDefUsesDefaultGeometry() async throws {
+            // 구역의 유일한 문단이 placeholder면 sectionDef/column 컨트롤이
+            // 없다 — 조판은 기본 지오메트리 폴백(`?? HwpSectionDef()`)으로
+            // 페이지를 만들어야 한다 (#65 하류 안전).
+            var section = CoreHwp.HwpFile().sectionArray[0]
+            section.paragraph = [CoreHwp.HwpParagraph.parseFailurePlaceholder(
+                record: HwpRecord(tagId: 66, level: 0, payload: Data()),
+                error: .recordDoesNotExist(tag: 68)
+            )]
+            let paginator = HwpPaginator(
+                sections: [section],
+                index: HwpIndex(from: CoreHwp.HwpFile()),
+                fontResolver: .testDeterministic
+            )
+
+            let page = try await paginator.page(at: 0)
+            let unsupported = await paginator.unsupportedElements()
+
+            expect(page).notTo(beNil())
+            expect(unsupported.filter { $0.hint.contains("손상 문단 복구") }.count) == 1
+        }
+
         func testHealthySectionsReportNoRecoveryPlaceholders() async throws {
             let file = CoreHwp.HwpFile()
             let paginator = HwpPaginator(


### PR DESCRIPTION
## 개요

손상된 문단·구역을 **placeholder로 대체해 나머지 본문을 복구**하는 best-effort 모드(#65)와, 그에 인접한 안정성 테스트 및 파서 정리(#67)를 담습니다. `recoverPartialContent`의 기본값은 `false`여서 종전처럼 fail-fast로 동작하고, `.viewer` 프리셋은 이 옵션을 켭니다.

## #65 — 손상 문단·구역 부분 복구

- `HwpLoadOptions.recoverPartialContent`(기본 `false`)를 추가했습니다. 이 옵션을 켜면 `HwpSection.load`가 문단 헤더와 하위 레코드의 개수 불일치, 필수 레코드 누락 등으로 파싱에 실패한 중간·뒤 문단을 문단 placeholder로 대체합니다. `HwpFile`은 구역 스트림 전체를 파싱하지 못하거나 첫 문단 파싱 실패가 전파되면 이를 구역 placeholder로 대체합니다.
  - 문단 placeholder: `paraText == nil`로 두고 원본 레코드를 `unknownChildren`에 보존
  - 구역 placeholder: 빈 문서 템플릿 문단(`sectionDef` + `column`)으로 구역 수와 조판 경계를 보존
- 새 공개 필드인 `HwpParagraph.parseFailure` / `HwpSection.parseFailure`(`String?`)에 실패 원인을 기록합니다. placeholder와 실제 빈 문단·구역을 구분해야 하므로 두 필드는 `Equatable`/`Hashable` 비교에 포함됩니다.
- **`recovery-exempt` 오류 3종**은 복구 모드에서도 그대로 전파됩니다: 자원 한도 2종(`streamSizeLimitExceeded`·`aggregateStreamSizeLimitExceeded`)과 `unsupportedFeature`(암호·배포용·DRM). `invalidRecordTree` 같은 구조 손상은 복구 대상입니다.
- 손상된 **메모 문단**도 개별 placeholder로 복구해 메모 그룹 경계를 보존합니다.
- **`ViewText`에는 복구를 적용하지 않습니다.** 구역 하나라도 파싱에 실패하면 표시본을 전량 폐기하고 `BodyText`로 강등하는 기존 채택 규칙을 유지합니다. placeholder로 구역 수를 보존하면 불완전한 표시본이 채택되어 해당 구역이 백지가 될 수 있기 때문입니다.
- `.viewer` 프리셋은 이 옵션을 켭니다. 뷰어는 문단 하나의 손상 때문에 전체 문서가 백지가 되는 대신 나머지 본문을 렌더링하며, placeholder는 `HwpPaginator.unsupportedElements()`에 `kind: .placeholder` 진단으로 노출됩니다. 메모 placeholder는 호스트 문단 자체의 `parseFailure`에는 드러나지 않으므로 `HwpPaginator`가 메모 그룹과 컨트롤 안의 중첩 문단까지 재귀적으로 검사합니다.

![두 번째 구역 손상을 placeholder로 복구해 정상 1쪽과 빈 2쪽을 보존한 샘플 앱 화면](https://github.com/user-attachments/assets/86682a92-e752-4dae-b6dc-6f9483d65875)

## #67 — 안정성 테스트 보강 및 파서 정리

- `HwpParaText.wcharCount`를 접근할 때마다 `reduce`로 계산하던 방식에서 **파싱 루프에서 누적하는 저장값**으로 전환했습니다. 값과 공개 API는 같고(`charArray` 변경 시 `didSet`으로 재동기화), 파생값이므로 직접 구현한 `Codable`의 기존 인코딩 형상(`rawPayload`와 `charArray` 두 키)을 유지하며 `Equatable`/`Hashable` 비교에서는 제외합니다. `PARA_HEADER` 문자 수 검증 결과는 유지하면서 `charArray`를 반복해서 순회하던 비용을 없앴습니다.
- 표 셀 헤더의 **도달할 수 없는** 음수 `paragraphCount` 가드를 제거했습니다. 표 셀은 `UInt16`을 `Int32`로 승격해 읽으므로 값이 항상 0 이상입니다. `bytes 6–7`은 셀 확장 속성이어서 리스트·글상자처럼 읽기 폭을 `Int32`로 넓힐 수 없다는 근거를 주석으로 명시했습니다. 동작 변화는 없습니다.

## 테스트

- `ParagraphRecoveryPlaceholderTests`/`ParagraphMemoRecursionTests`/`SectionNestedAdversarialTests` — 복구 placeholder 생성·메모·중첩 적대 입력(복구 비활성 대조군 포함)
- `HwpErrorTests.testRecoveryExemptSetCoversResourceLimitsAndUnsupportedFeature` — 복구 예외 집합을 `HwpError` 케이스별로 고정(`invalidRecordTree`가 복구 예외가 아님을 명시)
- `ControlFallbackErrorSetSpecTests` — 복구와 별개인 `canFallbackToRaw*` 컨트롤 폴백 집합 명세
- `ParaTextWcharCountTests` — `didSet` 재동기화·round-trip 동등성
- `HwpPaginatorRecoveryPlaceholderTests` — 뷰어 진단 노출
- `LegacyArchiveDecodingTests` — 새 필드와 기존 아카이브의 호환성

## 문서

지식 베이스 5곳을 갱신했습니다: 루트 `AGENTS.md`(부분 복구·`Codable` 계약), `Sources/CoreHwp`(복구 처리의 명시적 예외), `Sources/CoreHwp/Models/Section`(placeholder·`wcharCount` 계약), `Sources/HwpKitCore`(진단 노출), `Tests/CoreHwpTests`(복구 테스트 모음).

Closes #65
Closes #67