### PR TITLE
feat(diagnostics): HwpFile 미해석 요소 집계 API 및 손상 복구 진단 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # 프로젝트 지식 베이스
 
-**Branch:** feat/partial-content-recovery
+**Branch:** feat/parse-diagnostics
 
 ## 개요
 
@@ -166,6 +166,60 @@ Equatable/Hashable에서도 제외된다 (payload **유무** 파생이라 `HwpCh
 헤더의 **도달 불가능한** 음수 `paragraphCount` 가드도 제거됐다 — 표 셀은
 `UInt16`을 `Int32`로 승격해 읽어 항상 비음수다 (리스트/글상자와 달리 bytes 6-7이
 셀 확장 속성이라 읽기 폭을 넓힐 수 없다는 근거를 주석으로 못박음). 되살리지 말 것.
+
+## 미해석 요소 집계 (#66)
+
+`HwpFile.parseDiagnostics()`가 문서 전체를 순회해 파서가 해석하지 못한 요소를
+`[HwpParseDiagnostic]`(kind + tagId/ctrlId + path + detail)로 집계한다 —
+`HwpFile`의 첫 `extension`이고, 타입은
+[`Models/HwpParseDiagnostic.swift`](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/Models/HwpParseDiagnostic.swift)에
+있다. 용도는 QA·텔레메트리·버그 리포트·픽스처 회귀 신호다.
+
+- **역할 경계**: `HwpUnsupportedDetector`/`unsupportedElements()`는 "미지원
+  요소가 **화면에서** placeholder로 보이는가"(조판된 쪽에 실린 컨트롤 한정)를,
+  `parseDiagnostics()`는 "파서가 무엇을 해석하지 못했는가"(조판 무관, ViewText·
+  메모·중첩 문단 포함)를 다룬다. 이 문장은 Detector doc-comment에도 있다.
+- **kind 6종**: `unknownRecord`(모든 `unknownRecords`/`unknownChildren` +
+  `HwpUnknownRecord.children` 재귀 — `.child[i]` 세그먼트),
+  `unknownControl`/`notImplementedControl`(`HwpCtrlId` 두 raw case — 이때
+  `ctrlId` 채움), `recoveredSection`/`recoveredParagraph`/`recoveredMemoParagraph`
+  (복구 placeholder — `detail`에 `parseFailure` 사유).
+- **순회 범위**: DocInfo(최상위 `unknownRecords` + idMappings/docData/
+  distributeDocData/compatibleDocument/layoutCompatibility/raw record 계열의
+  `unknownChildren`) → `sectionArray`·`viewSectionArray`(path 접두사
+  `section[i]`/`viewSection[i]`로 갈림) → 문단 → 컨트롤 재귀(표 셀·리스트
+  4종·글상자·shape component detail 16종·ctrlData) → 메모 그룹
+  (`memo[g].paragraph[m]` — 그룹 인덱스가 메모 하나를 특정).
+- **이중 보고 방지 별칭 규칙** — 걷지 않는 필드가 넷 있다:
+  `HwpShapeControl.eqEditRecords`/`HwpShapeComponent.oleRecords`(typed 배열의
+  raw 사본), `HwpListControl.header.unknownChildren`(`HwpCtrlHeader.load`가
+  typed 소비된 리스트·문단까지 **전체** child를 raw로 담음),
+  DocInfo **결합 배열의 소유 구간**(`memoShape`/`trackChange`/
+  `trackChangeContent`/`trackChangeAuthor`는 idMappings 소유 구간,
+  `forbiddenChar`는 idMappings **+ docData** 소유 구간 — 각각
+  `docInfo.idMappings.…`/`docInfo.docData.forbiddenChar[i]` 경로에서 이미
+  보고되므로 최상위 구간만 결합 인덱스로 걷는다). 최상위
+  `docInfo.layoutCompatibility`는 compatibleDocument child의 **폴백 별칭**일 수
+  있어 값이 같으면 건너뛴다. `.unknown`/`.notImplemented` 컨트롤의
+  `header.unknownChildren`는 반대로 **걷는다** — 그 컨트롤은 아무것도 typed
+  소비하지 않았다.
+- **인접 정정**: 문단의 메모 계열 소비(`HwpParagraph.unconsumedRecords`)가 태그
+  blanket 제외에서 **실제 소비 인덱스** 기반으로 바뀌었다. 종전에는 첫
+  MEMO_LIST 앞의 stray 문단(66) child가 typed 소비도 raw 보존도 없이 모델에서
+  사라졌고(집계가 구조적으로 볼 수 없는 유실), 문단 없는 MEMO_LIST는 빈 그룹
+  으로 typed 소비됐는데도 unknownChildren에 중복 보존됐다. 둘 다 #66 리뷰에서
+  발견·수정 — 가드는 `ParagraphMemoRecursionTests`의 stray/빈 그룹 테스트.
+- **계약**: 결정적 순서 — 컨테이너(구역·문단·컨트롤) 순회는 문서 순서,
+  컨테이너 **안**은 종류별 그룹 순서다(unknown record → 문단/컨트롤 재귀 —
+  파스가 두 배열로 분리하며 원 스트림의 interleaving 위치를 버리므로 walker
+  층에서 복원 불가). `.default`와 `.viewer`의 진단 동일
+  (`HwpUnknownRecord`가 보존 off에서도 payload를 분리 복사로 유지하는 이유).
+  walker 자체 깊이 상한 없음 — 파스 시점 `maxNestingDepth`(#64)가 이미 유계.
+  정상 픽스처 전수(전 33종 중 expectedError 4종 제외 29종)에서 복구 kind 0건, 실저장본 진단은
+  `legacy-common-control-property`의 hiddenComment 계열 3건이 비-공허 앵커다.
+  스위트: `Models/Document/ParseDiagnosticsTests.swift`(합성) +
+  `FixtureHarness/FixtureRegression/FixtureParseDiagnosticsTests.swift`(픽스처
+  전수·manifest 대조·track-changes 주입 분리).
 
 ## 컨벤션
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,9 +181,24 @@ Equatable/Hashable에서도 제외된다 (payload **유무** 파생이라 `HwpCh
   메모·중첩 문단 포함)를 다룬다. 이 문장은 Detector doc-comment에도 있다.
 - **kind 6종**: `unknownRecord`(모든 `unknownRecords`/`unknownChildren` +
   `HwpUnknownRecord.children` 재귀 — `.child[i]` 세그먼트),
-  `unknownControl`/`notImplementedControl`(`HwpCtrlId` 두 raw case — 이때
-  `ctrlId` 채움), `recoveredSection`/`recoveredParagraph`/`recoveredMemoParagraph`
+  `unknownControl`/`notImplementedControl`(컨트롤 단위 — 이때 `ctrlId` 채움),
+  `recoveredSection`/`recoveredParagraph`/`recoveredMemoParagraph`
   (복구 placeholder — `detail`에 `parseFailure` 사유).
+- **`notImplementedControl`은 `HwpCtrlId.notImplemented`만이 아니다.** typed 승격
+  실패 시 표·도형은 `.notImplemented`로 떨어지지만 other/field 계열은 **제네릭
+  래퍼**로 보존된다 (`columnOrOther`·`sectionDefOrOther`·
+  `pageNumberPositionOrOther`·`listControlOrOther` → `.other`,
+  `hyperLinkOrField` → `.field`). 그 래퍼도 같은 kind로 보고한다 — **자식이 없는
+  폴백은 보고하지 않으면 진단이 통째로 비어** QA·텔레메트리가 완전한 파스로
+  오인한다. 판별은 **비대칭**이다: `.other`는 `HwpOtherCtrlId` 17종이 전용 파서
+  7종 아니면 `otherControl`이 이름 붙인 case 10종으로 남김없이 라우팅되므로
+  **도달 자체가 폴백의 증거**지만, `.field`는 대부분의 field id에게 제자리라
+  `ctrlId == .hyperLink`일 때만 폴백이다. "래퍼면 무조건 보고"로 넓히면 정상
+  `.field` 컨트롤이 전부 오탐되므로 음성 대조군이 짝으로 있다
+  (`ParseDiagnosticsFallbackTests`). 폴백 자체가 `HwpError` 3종
+  (`canFallbackToRawControl`)에만 열려 있어 `recordDoesNotExist`처럼 그 밖의
+  오류는 전파된다 — 합성 입력으로 이 경로를 재현하려면 그 집합 안의 오류를
+  유도해야 한다.
 - **순회 범위**: DocInfo(최상위 `unknownRecords` + idMappings/docData/
   distributeDocData/compatibleDocument/layoutCompatibility/raw record 계열의
   `unknownChildren`) → `sectionArray`·`viewSectionArray`(path 접두사

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ hwp-swift/
 |------|------|
 | 새 stream 파서 추가 | `Sources/CoreHwp/Streams/` + `HwpFile.init(fromOLE:)`에 등록 |
 | 새 record 태그 추가 | `Sources/CoreHwp/Enums/Hwp{DocInfo,Section}Tag.swift` |
-| 새 컨트롤 ID 추가 | `Sources/CoreHwp/Enums/CtrlId/` + `Models/Section/CtrlHeader/` + `HwpCtrlId` enum |
+| 새 컨트롤 ID 추가 | `Sources/CoreHwp/Enums/CtrlId/` + `Models/Section/CtrlHeader/` + `HwpCtrlId` enum + `Models/HwpParseDiagnostic.swift`의 진단 순회 |
 | 새 모델 추가 | `Sources/CoreHwp/Models/...` 하위에 `Utils/Protocols/`의 프로토콜을 채택하여 작성 |
 | 기본 타입 확장 | `Sources/CoreHwp/Utils/Extensions/` |
 | 테스트 픽스처 추가 | 테스트 파일과 같은 폴더에 `.hwp` 배치 (`openHwp(#file, "name")` 사용) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,22 @@
 
 ### Added
 
+- **미해석 요소 집계 API**가 들어왔습니다 (#66). 새 public 메서드
+  `HwpFile.parseDiagnostics()`가 문서 전체 — DocInfo·BodyText·ViewText(표시본)·
+  메모·표 셀/리스트/글상자 안 중첩 문단 — 를 순회해 파서가 해석하지 못한
+  요소를 `[HwpParseDiagnostic]`로 돌려줍니다. 진단은
+  kind(`unknownRecord`/`unknownControl`/`notImplementedControl`/
+  `recoveredSection`/`recoveredParagraph`/`recoveredMemoParagraph`) +
+  tagId/ctrlId + 위치 path(`"section[0].paragraph[12].ctrl[1].cell[0]…"`) +
+  detail(복구 placeholder의 `parseFailure` 사유)로 구성되며, 결과는 결정적이고
+  `.default`/`.viewer` 두 로드 모드에서 같습니다. 렌더 스택의
+  `HwpUnsupportedDetector`("미지원 요소가 화면에서 placeholder로 보이는가")와
+  달리 조판과 무관하게 "파서가 무엇을 해석하지 못했는가"를 다루는 QA·
+  텔레메트리·버그 리포트·픽스처 회귀용 표면입니다. 인접 정정으로, 문단의
+  메모 계열 소비가 태그 blanket 제외에서 실제 소비 인덱스 기반으로 바뀌어
+  첫 MEMO_LIST 앞의 stray 문단 record가 `unknownChildren`에 보존되고(종전에는
+  모델에서 소리 없이 사라짐), 문단 없는 MEMO_LIST가 빈 그룹으로 typed 소비
+  됐는데도 `unknownChildren`에 중복 보존되던 것이 제거됐습니다.
 - **손상 문단·구역 best-effort 복구**가 들어왔습니다 (#65).
   `HwpLoadOptions.recoverPartialContent`(기본 `false`)를 켜면 문단 카운트
   불일치·필수 레코드 누락 같은 문단 파싱 실패, 그리고 구역 스트림 파싱 실패가

--- a/Sources/CoreHwp/AGENTS.md
+++ b/Sources/CoreHwp/AGENTS.md
@@ -197,5 +197,6 @@ payload를 읽기 전에 `HwpError.invalidRecordTree`로 거부합니다. 실문
 | 미구현/알 수 없는 control | `.notImplemented` 또는 `.unknown`으로 raw payload 보존. 실제 fixture section stream 기반 주입 테스트로 unknown control payload/child 보존을 확인 |
 | 암호 문서 | `HwpError.unsupportedFeature(.encryptedDocument)`. 공인 인증서 암호화 bit도 같은 unsupported로 처리 |
 | 배포용 문서 | `HwpError.unsupportedFeature(.deploymentDocument)` |
+| 미해석 요소 집계 | `HwpFile.parseDiagnostics()`가 unknown record/control·복구 placeholder를 kind+path로 집계 (`Models/HwpParseDiagnostic.swift`). BodyText·ViewText·DocInfo·메모·중첩 컨트롤 전부 순회, `.default`/`.viewer` 진단 동일. 이중 보고 방지 별칭 규칙은 루트 AGENTS.md "미해석 요소 집계 (#66)" |
 | DRM 문서 | `HwpError.unsupportedFeature(.drmDocument)`. 일반 DRM 및 공인 인증서 DRM bit 모두 차단 |
 | 쓰기/저장 | 미지원 |

--- a/Sources/CoreHwp/AGENTS.md
+++ b/Sources/CoreHwp/AGENTS.md
@@ -74,6 +74,12 @@ ID로 dispatch된다.
 3. `Enums/CtrlId/HwpCtrlId.swift`의 enum에 case 추가하고, manual
    `Codable` 구현 (`CodingKeys`, `init(from:)`, `encode(to:)`)도 갱신할 것.
    이종 associated value 때문에 자동 합성되지 않는다.
+4. `Models/HwpParseDiagnostic.swift`의 `collect(ctrl:)`에 진단 순회 case를
+   추가한다. `default:` 없는 exhaustive switch라 컴파일러가 누락을 잡아 준다 —
+   **`default:`를 넣어 통과시키지 말 것** (그 순간 새 컨트롤의 미해석 자식이
+   집계에서 조용히 빠진다). 렌더 스택의
+   `HwpUnsupportedDetector.unsupportedHint`와 같은 컨벤션이고, 현재 `HwpCtrlId`
+   전수 switch는 이 둘뿐이다 (`unsupportedComponentHint`는 `default:`가 있다).
 
 ## 컨벤션
 

--- a/Sources/CoreHwp/Models/HwpParseDiagnostic.swift
+++ b/Sources/CoreHwp/Models/HwpParseDiagnostic.swift
@@ -1,0 +1,455 @@
+import Foundation
+
+/// 파서가 해석하지 못한 요소 하나에 대한 진단.
+///
+/// `HwpFile.parseDiagnostics()`가 문서 전체를 순회해 만든다. 렌더 스택의
+/// `HwpUnsupportedDetector` 계열이 "미지원 요소가 화면에서 placeholder로
+/// 보이는가"(뷰어 UI)를 다루는 것과 달리, 이 타입은 조판과 무관하게 "파서가
+/// 무엇을 해석하지 못했는가"(QA·텔레메트리·버그 리포트·픽스처 회귀 신호)를
+/// 다룬다 (#66).
+public struct HwpParseDiagnostic: HwpPrimitive {
+    /// 진단 종류.
+    public enum Kind: String, HwpPrimitive {
+        /// 해석하지 못하고 raw payload로 보존한 record
+        /// (`unknownRecords`·`unknownChildren`와 그 하위 record)
+        case unknownRecord
+        /// ctrl id 자체를 알지 못하는 컨트롤 (`HwpCtrlId.unknown`)
+        case unknownControl
+        /// ctrl id는 알지만 typed 파싱이 없거나 raw 폴백으로 보존한 컨트롤
+        /// (`HwpCtrlId.notImplemented`)
+        case notImplementedControl
+        /// 복구 모드(#65)에서 구역 전체가 placeholder로 대체됨
+        case recoveredSection
+        /// 복구 모드에서 문단이 placeholder로 대체됨
+        case recoveredParagraph
+        /// 복구 모드에서 메모 본문 문단이 placeholder로 대체됨
+        case recoveredMemoParagraph
+    }
+
+    public let kind: Kind
+    /// unknown record의 tag ID. record 진단이 아니면 nil.
+    public let tagId: UInt32?
+    /// 컨트롤 진단의 4-byte ctrl ID. 컨트롤 진단이 아니면 nil.
+    public let ctrlId: UInt32?
+    /// 요소 위치. 예: `"section[0].paragraph[12].ctrl[1].cell[0].paragraph[0]"`.
+    /// BodyText는 `section[i]`, ViewText 표시본은 `viewSection[i]`,
+    /// DocInfo는 `docInfo`로 시작한다.
+    public let path: String
+    /// 부가 정보 (placeholder의 `parseFailure` 사유 등). 없으면 nil.
+    public let detail: String?
+
+    public init(
+        kind: Kind,
+        tagId: UInt32? = nil,
+        ctrlId: UInt32? = nil,
+        path: String,
+        detail: String? = nil
+    ) {
+        self.kind = kind
+        self.tagId = tagId
+        self.ctrlId = ctrlId
+        self.path = path
+        self.detail = detail
+    }
+}
+
+public extension HwpFile {
+    /// 문서 전체를 순회해 파서가 해석하지 못한 요소를 집계한다.
+    ///
+    /// - 결과는 결정적이다. 컨테이너(구역·문단·컨트롤) 순회는 문서 순서를
+    ///   따르고, 컨테이너 **안**에서는 종류별 그룹 순서다(unknown record →
+    ///   문단/컨트롤 재귀) — 파스가 record를 종류별 배열로 분리하며 원 스트림의
+    ///   interleaving 위치를 버리므로 그 이상의 순서는 복원할 수 없다.
+    /// - BodyText(`sectionArray`)와 ViewText(`viewSectionArray`)를 모두 본다 —
+    ///   렌더 본문 선택(`displaySectionArray`)과 달리, 채택되지 않은 표시본이
+    ///   무엇을 담고 있었는지도 진단의 관심사다. 두 본문은 path 접두사
+    ///   (`section[i]` / `viewSection[i]`)로 갈린다.
+    /// - `.default`와 `.viewer` 로드 결과의 진단은 같다 — unknown record
+    ///   payload는 보존 off에서도 비워지지 않고 분리 복사된다 (`HwpUnknownRecord`).
+    /// - walker는 자체 깊이 상한을 두지 않는다. 순회할 트리는 파스 시점의
+    ///   `HwpReadLimits.maxNestingDepth`가 이미 상한했다 (#64).
+    func parseDiagnostics() -> [HwpParseDiagnostic] {
+        var collector = HwpParseDiagnosticCollector()
+        collector.collect(docInfo: docInfo)
+        for (index, section) in sectionArray.enumerated() {
+            collector.collect(section: section, path: "section[\(index)]")
+        }
+        for (index, section) in viewSectionArray.enumerated() {
+            collector.collect(section: section, path: "viewSection[\(index)]")
+        }
+        return collector.diagnostics
+    }
+}
+
+/// `parseDiagnostics()`의 순회 상태 — path 문자열을 조립하며 진단을 누적한다.
+private struct HwpParseDiagnosticCollector {
+    var diagnostics = [HwpParseDiagnostic]()
+}
+
+// MARK: - unknown record 공통 수집
+
+private extension HwpParseDiagnosticCollector {
+    /// record 하나와 그 하위 트리를 보고한다. 하위 record는 트리로 보존되므로
+    /// (`HwpUnknownRecord.children`) `.child[i]` 세그먼트로 재귀한다.
+    mutating func collect(record: HwpUnknownRecord, path: String) {
+        diagnostics.append(
+            HwpParseDiagnostic(kind: .unknownRecord, tagId: record.tagId, path: path)
+        )
+        for (index, child) in record.children.enumerated() {
+            collect(record: child, path: "\(path).child[\(index)]")
+        }
+    }
+
+    mutating func collect(records: [HwpUnknownRecord], segment: String, under path: String) {
+        for (index, record) in records.enumerated() {
+            collect(record: record, path: "\(path).\(segment)[\(index)]")
+        }
+    }
+
+    mutating func collectUnknownChildren(_ records: [HwpUnknownRecord], under path: String) {
+        collect(records: records, segment: "unknownChild", under: path)
+    }
+
+    mutating func collect(ctrlDataRecords: [HwpCtrlData], under path: String) {
+        for (index, ctrlData) in ctrlDataRecords.enumerated() {
+            collectUnknownChildren(ctrlData.unknownChildren, under: "\(path).ctrlData[\(index)]")
+        }
+    }
+}
+
+// MARK: - DocInfo
+
+private extension HwpParseDiagnosticCollector {
+    mutating func collect(docInfo: HwpDocInfo) {
+        collect(records: docInfo.unknownRecords, segment: "unknownRecord", under: "docInfo")
+        collect(idMappings: docInfo.idMappings)
+        if let docData = docInfo.docData {
+            for (index, forbiddenChar) in docData.forbiddenCharArray.enumerated() {
+                collectUnknownChildren(
+                    forbiddenChar.unknownChildren,
+                    under: "docInfo.docData.forbiddenChar[\(index)]"
+                )
+            }
+            collectUnknownChildren(docData.unknownChildren, under: "docInfo.docData")
+        }
+        if let distributeDocData = docInfo.distributeDocData {
+            collectUnknownChildren(
+                distributeDocData.unknownChildren, under: "docInfo.distributeDocData"
+            )
+        }
+        collect(compatibleDocument: docInfo.compatibleDocument)
+        collectTopLevelLayoutCompatibility(docInfo)
+        collectTopLevelCombinedRecords(docInfo)
+    }
+
+    mutating func collect(idMappings: HwpIdMappings) {
+        let path = "docInfo.idMappings"
+        collectUnknownChildren(idMappings.unknownChildren, under: path)
+        collectRecordChildren(
+            idMappings.memoShapeArray.map(\.unknownChildren), segment: "memoShape", under: path
+        )
+        collectRecordChildren(
+            idMappings.trackChangeArray.map(\.unknownChildren), segment: "trackChange", under: path
+        )
+        collectRecordChildren(
+            idMappings.trackChangeContentArray.map(\.unknownChildren),
+            segment: "trackChangeContent",
+            under: path
+        )
+        collectRecordChildren(
+            idMappings.trackChangeAuthorArray.map(\.unknownChildren),
+            segment: "trackChangeAuthor",
+            under: path
+        )
+        collectRecordChildren(
+            idMappings.forbiddenCharArray.map(\.unknownChildren),
+            segment: "forbiddenChar",
+            under: path
+        )
+    }
+
+    mutating func collect(compatibleDocument: HwpCompatibleDocument?) {
+        guard let compatibleDocument else { return }
+        let path = "docInfo.compatibleDocument"
+        collectUnknownChildren(compatibleDocument.unknownChildren, under: path)
+        if let layoutCompatibility = compatibleDocument.layoutCompatibility {
+            collectUnknownChildren(
+                layoutCompatibility.unknownChildren, under: "\(path).layoutCompatibility"
+            )
+        }
+        collectRecordChildren(
+            compatibleDocument.trackChangeArray.map(\.unknownChildren),
+            segment: "trackChange",
+            under: path
+        )
+    }
+
+    /// 최상위 LAYOUT_COMPATIBILITY. 최상위 record가 없으면
+    /// `docInfo.layoutCompatibility`는 `compatibleDocument` child의 폴백 별칭이라
+    /// (HwpDocInfo 파스) 같은 값이면 건너뛰어 이중 보고를 막는다.
+    /// `unknownChildren`은 `@ExcludeEquatable`이라 별도로 비교한다.
+    mutating func collectTopLevelLayoutCompatibility(_ docInfo: HwpDocInfo) {
+        guard let layoutCompatibility = docInfo.layoutCompatibility else { return }
+        if let alias = docInfo.compatibleDocument?.layoutCompatibility,
+           alias == layoutCompatibility,
+           alias.unknownChildren == layoutCompatibility.unknownChildren
+        {
+            return
+        }
+        collectUnknownChildren(
+            layoutCompatibility.unknownChildren, under: "docInfo.layoutCompatibility"
+        )
+    }
+
+    /// 결합 배열(idMappings 소유분 + 최상위분 — `HwpDocInfo` 파스가 이 순서로
+    /// 이어 붙인다)의 최상위 구간만 걷는다. idMappings 소유분은
+    /// `collect(idMappings:)`가 이미 보고했다. path 인덱스는 결합 배열
+    /// (`docInfo.memoShapeArray` 등) 기준이라 그대로 조회할 수 있다.
+    mutating func collectTopLevelCombinedRecords(_ docInfo: HwpDocInfo) {
+        let idMappings = docInfo.idMappings
+        collectRecordChildren(
+            docInfo.memoShapeArray.map(\.unknownChildren),
+            segment: "memoShape",
+            under: "docInfo",
+            skippingFirst: idMappings.memoShapeArray.count
+        )
+        collectRecordChildren(
+            docInfo.trackChangeArray.map(\.unknownChildren),
+            segment: "trackChange",
+            under: "docInfo",
+            skippingFirst: idMappings.trackChangeArray.count
+        )
+        collectRecordChildren(
+            docInfo.trackChangeContentArray.map(\.unknownChildren),
+            segment: "trackChangeContent",
+            under: "docInfo",
+            skippingFirst: idMappings.trackChangeContentArray.count
+        )
+        collectRecordChildren(
+            docInfo.trackChangeAuthorArray.map(\.unknownChildren),
+            segment: "trackChangeAuthor",
+            under: "docInfo",
+            skippingFirst: idMappings.trackChangeAuthorArray.count
+        )
+        // forbiddenChar 결합 배열은 idMappings + docData + 최상위 순 —
+        // 앞 두 구간은 각자의 소유 경로에서 이미 보고했다.
+        let ownedForbiddenCharCount = idMappings.forbiddenCharArray.count
+            + (docInfo.docData?.forbiddenCharArray.count ?? 0)
+        collectRecordChildren(
+            docInfo.forbiddenCharArray.map(\.unknownChildren),
+            segment: "forbiddenChar",
+            under: "docInfo",
+            skippingFirst: ownedForbiddenCharCount
+        )
+    }
+
+    mutating func collectRecordChildren(
+        _ unknownChildrenArray: [[HwpUnknownRecord]],
+        segment: String,
+        under path: String,
+        skippingFirst ownedCount: Int = 0
+    ) {
+        guard unknownChildrenArray.count > ownedCount else { return }
+        for index in ownedCount ..< unknownChildrenArray.count {
+            collectUnknownChildren(
+                unknownChildrenArray[index], under: "\(path).\(segment)[\(index)]"
+            )
+        }
+    }
+}
+
+// MARK: - 구역·문단
+
+private extension HwpParseDiagnosticCollector {
+    mutating func collect(section: HwpSection, path: String) {
+        if let parseFailure = section.parseFailure {
+            diagnostics.append(
+                HwpParseDiagnostic(kind: .recoveredSection, path: path, detail: parseFailure)
+            )
+        }
+        collect(records: section.unknownRecords, segment: "unknownRecord", under: path)
+        for (index, paragraph) in section.paragraph.enumerated() {
+            collect(
+                paragraph: paragraph,
+                path: "\(path).paragraph[\(index)]",
+                isMemoParagraph: false
+            )
+        }
+    }
+
+    mutating func collect(paragraph: HwpParagraph, path: String, isMemoParagraph: Bool) {
+        if let parseFailure = paragraph.parseFailure {
+            diagnostics.append(HwpParseDiagnostic(
+                kind: isMemoParagraph ? .recoveredMemoParagraph : .recoveredParagraph,
+                path: path,
+                detail: parseFailure
+            ))
+        }
+        collectUnknownChildren(paragraph.unknownChildren, under: path)
+        for (index, ctrl) in (paragraph.ctrlHeaderArray ?? []).enumerated() {
+            collect(ctrl: ctrl, path: "\(path).ctrl[\(index)]")
+        }
+        // 메모별 그룹이 경계의 단일 출처다. 그룹 키가 없는 legacy 아카이브만
+        // 평탄 배열을 그룹 하나로 간주해 폴백한다 (파스는 둘을 함께 채운다).
+        let memoGroups = paragraph.memoParagraphGroups
+            ?? paragraph.memoParagraphArray.map { [$0] }
+            ?? []
+        for (groupIndex, group) in memoGroups.enumerated() {
+            for (index, memoParagraph) in group.enumerated() {
+                collect(
+                    paragraph: memoParagraph,
+                    path: "\(path).memo[\(groupIndex)].paragraph[\(index)]",
+                    isMemoParagraph: true
+                )
+            }
+        }
+    }
+}
+
+// MARK: - 컨트롤
+
+private extension HwpParseDiagnosticCollector {
+    // HwpCtrlId 스위치는 `default:` 없이 exhaustive로 둔다 — 새 컨트롤 case가
+    // 추가되면 컴파일러가 진단 순회 누락을 강제로 잡는다
+    // (`HwpUnsupportedDetector.unsupportedHint`와 같은 컨벤션).
+    // swiftlint:disable:next cyclomatic_complexity
+    mutating func collect(ctrl: HwpCtrlId, path: String) {
+        switch ctrl {
+        case let .table(table):
+            collect(table: table, path: path)
+        case let .shape(control), let .line(control), let .rectangle(control),
+             let .ellipse(control), let .arc(control), let .polygon(control),
+             let .curve(control), let .equation(control), let .equationLegacy(control),
+             let .picture(control), let .ole(control), let .container(control):
+            collect(shapeControl: control, path: path)
+        case let .genShapeObject(object):
+            collect(genShapeObject: object, path: path)
+        case let .section(sectionDef):
+            collectUnknownChildren(sectionDef.unknownChildren, under: path)
+        case let .column(column):
+            collectUnknownChildren(column.unknownChildren, under: path)
+        case let .pageNumberPosition(position):
+            collectUnknownChildren(position.unknownChildren, under: path)
+        case let .header(control), let .footer(control),
+             let .footnote(control), let .endnote(control):
+            collect(listControl: control, path: path)
+        case let .form(control), let .autoNumber(control), let .newNumber(control),
+             let .pageHide(control), let .pageCT(control), let .indexmark(control),
+             let .bookmark(control), let .overlapping(control), let .comment(control),
+             let .hiddenComment(control), let .other(control):
+            collectUnknownChildren(control.unknownChildren, under: path)
+            collect(ctrlDataRecords: control.ctrlDataRecords, under: path)
+        case let .hyperLink(hyperlink):
+            collectUnknownChildren(hyperlink.unknownChildren, under: path)
+        case let .memo(control), let .revision(control), let .field(control):
+            collectUnknownChildren(control.unknownChildren, under: path)
+        case let .notImplemented(header):
+            diagnostics.append(
+                HwpParseDiagnostic(kind: .notImplementedControl, ctrlId: header.ctrlId, path: path)
+            )
+            collectUnknownChildren(header.unknownChildren, under: path)
+        case let .unknown(header):
+            diagnostics.append(
+                HwpParseDiagnostic(kind: .unknownControl, ctrlId: header.ctrlId, path: path)
+            )
+            collectUnknownChildren(header.unknownChildren, under: path)
+        }
+    }
+
+    mutating func collect(table: HwpTable, path: String) {
+        collectUnknownChildren(table.unknownChildren, under: path)
+        for (cellIndex, cell) in table.cellArray.enumerated() {
+            let cellPath = "\(path).cell[\(cellIndex)]"
+            collectUnknownChildren(cell.header.unknownChildren, under: cellPath)
+            for (index, paragraph) in cell.paragraphArray.enumerated() {
+                collect(
+                    paragraph: paragraph,
+                    path: "\(cellPath).paragraph[\(index)]",
+                    isMemoParagraph: false
+                )
+            }
+        }
+    }
+
+    mutating func collect(shapeControl: HwpShapeControl, path: String) {
+        collectUnknownChildren(shapeControl.unknownChildren, under: path)
+        for (index, component) in shapeControl.shapeComponentArray.enumerated() {
+            collect(shapeComponent: component, path: "\(path).shapeComponent[\(index)]")
+        }
+        // eqEditRecords는 eqEditArray로 typed 파싱된 같은 record의 raw 사본 —
+        // 걷지 않는다 (이중 보고 방지). oleRecords도 같은 이유로 component
+        // 순회에서 걷지 않는다.
+        for (index, eqEdit) in shapeControl.eqEditArray.enumerated() {
+            collectUnknownChildren(eqEdit.unknownChildren, under: "\(path).eqEdit[\(index)]")
+        }
+        collect(ctrlDataRecords: shapeControl.ctrlDataRecords, under: path)
+    }
+
+    mutating func collect(genShapeObject: HwpGenShapeObject, path: String) {
+        collectUnknownChildren(genShapeObject.unknownChildren, under: path)
+        for (index, component) in genShapeObject.shapeComponentArray.enumerated() {
+            collect(shapeComponent: component, path: "\(path).shapeComponent[\(index)]")
+        }
+        collect(ctrlDataRecords: genShapeObject.ctrlDataRecords, under: path)
+    }
+
+    /// 리스트 컨트롤 (머리말·꼬리말·각주·미주).
+    /// `header.unknownChildren`는 걷지 않는다 — `HwpCtrlHeader.load`가 컨트롤의
+    /// **전체** child record(listArray로 typed 소비된 리스트 헤더·문단 포함)를
+    /// raw로 담아 두므로, 보고하면 소비된 record가 이중 보고된다.
+    mutating func collect(listControl: HwpListControl, path: String) {
+        collectUnknownChildren(listControl.unknownChildren, under: path)
+        for (index, list) in listControl.listArray.enumerated() {
+            collect(listItem: list, path: "\(path).list[\(index)]")
+        }
+    }
+
+    mutating func collect(listItem: HwpListControlList, path: String) {
+        collectUnknownChildren(listItem.headerUnknownChildren, under: path)
+        for (index, paragraph) in listItem.paragraphArray.enumerated() {
+            collect(
+                paragraph: paragraph,
+                path: "\(path).paragraph[\(index)]",
+                isMemoParagraph: false
+            )
+        }
+    }
+
+    mutating func collect(shapeComponent: HwpShapeComponent, path: String) {
+        // 중첩 shape component(컨테이너의 자식 SHAPE_COMPONENT)는 typed 소비
+        // 대상이 아니라 unknownChildren에 남으므로 여기 record 재귀가 함께 잡는다.
+        collectUnknownChildren(shapeComponent.unknownChildren, under: path)
+        collectDetail(shapeComponent.pictureArray.map(\.unknownChildren), "picture", path)
+        collectDetail(shapeComponent.lineArray.map(\.unknownChildren), "line", path)
+        collectDetail(shapeComponent.rectangleArray.map(\.unknownChildren), "rectangle", path)
+        collectDetail(shapeComponent.ellipseArray.map(\.unknownChildren), "ellipse", path)
+        collectDetail(shapeComponent.arcArray.map(\.unknownChildren), "arc", path)
+        collectDetail(shapeComponent.polygonArray.map(\.unknownChildren), "polygon", path)
+        collectDetail(shapeComponent.curveArray.map(\.unknownChildren), "curve", path)
+        collectDetail(shapeComponent.oleArray.map(\.unknownChildren), "ole", path)
+        collectDetail(shapeComponent.containerArray.map(\.unknownChildren), "container", path)
+        collectDetail(shapeComponent.chartDataArray.map(\.unknownChildren), "chartData", path)
+        collectDetail(shapeComponent.textartArray.map(\.unknownChildren), "textart", path)
+        collectDetail(shapeComponent.formObjectArray.map(\.unknownChildren), "formObject", path)
+        collectDetail(shapeComponent.memoShapeArray.map(\.unknownChildren), "memoShape", path)
+        collectDetail(shapeComponent.memoListArray.map(\.unknownChildren), "memoList", path)
+        collectDetail(shapeComponent.videoDataArray.map(\.unknownChildren), "videoData", path)
+        collectDetail(
+            shapeComponent.shapeComponentUnknownArray.map(\.unknownChildren),
+            "shapeComponentUnknown",
+            path
+        )
+        collect(ctrlDataRecords: shapeComponent.ctrlDataRecords, under: path)
+        for (index, textBox) in shapeComponent.textBoxListArray.enumerated() {
+            collect(listItem: textBox, path: "\(path).textBox[\(index)]")
+        }
+    }
+
+    mutating func collectDetail(
+        _ unknownChildrenArray: [[HwpUnknownRecord]],
+        _ segment: String,
+        _ path: String
+    ) {
+        collectRecordChildren(unknownChildrenArray, segment: segment, under: path)
+    }
+}

--- a/Sources/CoreHwp/Models/HwpParseDiagnostic.swift
+++ b/Sources/CoreHwp/Models/HwpParseDiagnostic.swift
@@ -15,8 +15,9 @@ public struct HwpParseDiagnostic: HwpPrimitive {
         case unknownRecord
         /// ctrl id 자체를 알지 못하는 컨트롤 (`HwpCtrlId.unknown`)
         case unknownControl
-        /// ctrl id는 알지만 typed 파싱이 없거나 raw 폴백으로 보존한 컨트롤
-        /// (`HwpCtrlId.notImplemented`)
+        /// ctrl id는 알지만 typed 파싱이 없거나 raw 폴백으로 보존한 컨트롤.
+        /// `HwpCtrlId.notImplemented`(표·도형)와, 전용 파서가 승격에 실패해
+        /// 제네릭 `.other`/`.field` 래퍼로 떨어진 컨트롤이 모두 포함된다.
         case notImplementedControl
         /// 복구 모드(#65)에서 구역 전체가 placeholder로 대체됨
         case recoveredSection
@@ -336,24 +337,44 @@ private extension HwpParseDiagnosticCollector {
         case let .form(control), let .autoNumber(control), let .newNumber(control),
              let .pageHide(control), let .pageCT(control), let .indexmark(control),
              let .bookmark(control), let .overlapping(control), let .comment(control),
-             let .hiddenComment(control), let .other(control):
+             let .hiddenComment(control):
+            collectUnknownChildren(control.unknownChildren, under: path)
+            collect(ctrlDataRecords: control.ctrlDataRecords, under: path)
+        // `.other`에 남았다는 것 자체가 typed 승격 실패의 증거다 —
+        // `HwpOtherCtrlId` 17종은 전용 파서 7종(section·column·header·footer·
+        // footnote·endnote·pageNumberPosition) 아니면 `otherControl`이 이름 붙인
+        // case 10종으로 남김없이 라우팅되므로, 제네릭 래퍼에 도달하는 경로는
+        // 폴백뿐이다 (`HwpParagraph`의 컨트롤 dispatch).
+        case let .other(control):
+            appendControl(.notImplementedControl, ctrlId: control.ctrlId.rawValue, path: path)
             collectUnknownChildren(control.unknownChildren, under: path)
             collect(ctrlDataRecords: control.ctrlDataRecords, under: path)
         case let .hyperLink(hyperlink):
             collectUnknownChildren(hyperlink.unknownChildren, under: path)
-        case let .memo(control), let .revision(control), let .field(control):
+        case let .memo(control), let .revision(control):
+            collectUnknownChildren(control.unknownChildren, under: path)
+        // `.field`는 반대다 — 대부분의 field ctrl id에게 제자리이고, 전용 파서가
+        // 있는 hyperLink만 여기 남았을 때 승격 실패다 (`hyperLinkOrField`).
+        case let .field(control):
+            if control.ctrlId == .hyperLink {
+                appendControl(.notImplementedControl, ctrlId: control.ctrlId.rawValue, path: path)
+            }
             collectUnknownChildren(control.unknownChildren, under: path)
         case let .notImplemented(header):
-            diagnostics.append(
-                HwpParseDiagnostic(kind: .notImplementedControl, ctrlId: header.ctrlId, path: path)
-            )
+            appendControl(.notImplementedControl, ctrlId: header.ctrlId, path: path)
             collectUnknownChildren(header.unknownChildren, under: path)
         case let .unknown(header):
-            diagnostics.append(
-                HwpParseDiagnostic(kind: .unknownControl, ctrlId: header.ctrlId, path: path)
-            )
+            appendControl(.unknownControl, ctrlId: header.ctrlId, path: path)
             collectUnknownChildren(header.unknownChildren, under: path)
         }
+    }
+
+    mutating func appendControl(
+        _ kind: HwpParseDiagnostic.Kind,
+        ctrlId: UInt32,
+        path: String
+    ) {
+        diagnostics.append(HwpParseDiagnostic(kind: kind, ctrlId: ctrlId, path: path))
     }
 
     mutating func collect(table: HwpTable, path: String) {

--- a/Sources/CoreHwp/Models/Section/AGENTS.md
+++ b/Sources/CoreHwp/Models/Section/AGENTS.md
@@ -85,6 +85,18 @@ placeholder 생성이 이 폴더에 있으므로 그 형태 계약을 여기 남
   일 때 전파해 `HwpFile`이 구역 단위 placeholder로 승격시킨다 — 그 가드를
   지우면 경계 유실이 재발한다 (루트 "부분 복구").
 
+## 메모 계열 child 소비 (#66)
+
+`unconsumedRecords`는 메모 계열(MEMO_LIST 93·메모 문단 66)을 태그가 아니라
+**그룹 빌더가 실제 소비한 child 인덱스**로 제외한다. 태그 blanket 제외는 양쪽으로
+틀렸다 — 첫 MEMO_LIST **앞**의 stray 문단(66)은 그룹 빌더가 소비하지 않는데
+(`current == nil`) 함께 삼켜져 typed 소비도 raw 보존도 없이 모델에서 사라졌고,
+문단 없는 MEMO_LIST는 빈 그룹으로 typed 소비됐는데도 `unknownChildren`에 중복
+보존됐다. 전자는 미해석 요소 집계(`parseDiagnostics`)가 **구조적으로 볼 수 없는**
+유실이라 #66에서 고쳤다 — 이 폴더가 그 유실의 발생 지점이었다. 가드는
+`ParagraphMemoRecursionTests`의 stray/빈 그룹 테스트이고, 집계 쪽 계약은 루트
+`AGENTS.md` "미해석 요소 집계"에 있다.
+
 ## `HwpParaText.wcharCount` (#67)
 
 파스 루프가 실제로 소비한 wchar의 **누적 저장값**이다 (컨트롤 문자 = 8 wchar).
@@ -112,3 +124,6 @@ Codable은 `rawPayload`/`charArray` 두 키만 인코딩하고 디코더가 재�
 - `parseFailure` placeholder 로직을 다른 모델·다른 error로 넓히기 — 복구는
   문단·구역·메모 문단 한정이고 게이트는 `error.isRecoveryExempt`다 (루트
   "부분 복구").
+- 메모 계열 child를 **태그로** blanket 제외 — 소비 인덱스 기반이어야 한다
+  (위 "메모 계열 child 소비"). 되돌리면 stray 문단(66)이 typed 소비도 raw
+  보존도 없이 모델에서 사라진다.

--- a/Sources/CoreHwp/Models/Section/AGENTS.md
+++ b/Sources/CoreHwp/Models/Section/AGENTS.md
@@ -47,6 +47,9 @@ record는 4-byte 컨트롤 ID로 시작하며,
    subdirectory).
 3. `HwpCtrlId`에 case 추가, manual `Codable` 구현 갱신.
 4. 단락 dispatch에서 `.notImplemented(HwpCtrlHeader)`로부터 분리.
+5. `Models/HwpParseDiagnostic.swift`의 `collect(ctrl:)`에 진단 순회 case 추가
+   (`default:` 없는 exhaustive switch라 컴파일러가 강제한다 — 근거는 상위
+   `CoreHwp/AGENTS.md` 같은 절).
 
 ## 컨벤션
 

--- a/Sources/CoreHwp/Models/Section/HwpParagraph.swift
+++ b/Sources/CoreHwp/Models/Section/HwpParagraph.swift
@@ -168,15 +168,17 @@ public struct HwpParagraph: HwpFromRecordWithVersion {
 
         // MEMO_LIST(93)가 메모 하나를 열고, 그 뒤 문단(66)들이 그 메모의 본문이다.
         // 메모별 그룹을 보존해야 여러 문단짜리 메모/다중 메모가 필드와 어긋나지 않는다.
+        var consumedMemoChildIndexes = Set<Int>()
         if children.contains(where: { $0.tagId == HwpSectionTag.memoList.rawValue }) {
             var groups: [[HwpParagraph]] = []
             var current: [HwpParagraph]?
-            for child in children {
+            for (index, child) in children.enumerated() {
                 if child.tagId == HwpSectionTag.memoList.rawValue {
                     if let current {
                         groups.append(current)
                     }
                     current = []
+                    consumedMemoChildIndexes.insert(index)
                 } else if child.tagId == HwpSectionTag.paraHeader.rawValue, current != nil {
                     // 복구 모드에서는 손상 메모 문단도 placeholder로 대체한다 —
                     // 그대로 전파시키면 호스트 문단 전체가 placeholder가 되어
@@ -188,6 +190,7 @@ public struct HwpParagraph: HwpFromRecordWithVersion {
                     {
                         current?.append(.parseFailurePlaceholder(record: child, error: error))
                     }
+                    consumedMemoChildIndexes.insert(index)
                 }
             }
             if let current {
@@ -200,27 +203,29 @@ public struct HwpParagraph: HwpFromRecordWithVersion {
 
         unknownChildren = Self.unconsumedRecords(
             from: children,
-            consumesMemoRecords: memoParagraphArray != nil
+            consumedMemoChildIndexes: consumedMemoChildIndexes
         ).map(HwpUnknownRecord.init)
     }
 }
 
 private extension HwpParagraph {
+    /// 메모 계열(MEMO_LIST·메모 문단)은 태그가 아니라 **실제 소비한 child
+    /// 인덱스**로 제외한다. 태그 blanket 제외는 첫 MEMO_LIST 앞의 stray
+    /// 문단(66) record처럼 그룹 빌더가 소비하지 않은 record까지 삼켜, typed
+    /// 소비도 raw 보존도 없이 모델에서 사라지게 했다 — 미해석 요소 집계
+    /// (`parseDiagnostics`)가 구조적으로 볼 수 없는 유실이라 #66에서 고쳤다.
     static func unconsumedRecords(
         from children: [HwpRecord],
-        consumesMemoRecords: Bool
+        consumedMemoChildIndexes: Set<Int>
     ) -> [HwpRecord] {
         var consumedSingletons = Set<UInt32>()
 
-        return children.filter { child in
+        return children.enumerated().filter { index, child in
             if multiRecordTags.contains(child.tagId) {
                 return false
             }
 
-            if consumesMemoRecords,
-               child.tagId == HwpSectionTag.memoList.rawValue
-               || child.tagId == HwpSectionTag.paraHeader.rawValue
-            {
+            if consumedMemoChildIndexes.contains(index) {
                 return false
             }
 
@@ -233,7 +238,7 @@ private extension HwpParagraph {
             }
 
             return true
-        }
+        }.map(\.element)
     }
 
     static var singletonRecordTags: Set<UInt32> {

--- a/Sources/HwpKitCore/AGENTS.md
+++ b/Sources/HwpKitCore/AGENTS.md
@@ -78,6 +78,13 @@ CoreHwp.HwpFile
 유한). 복구 자체는 `CoreHwp` 파서에 있다 (루트 `AGENTS.md` "부분 복구") — 여기는
 그 진단 노출만 담당한다.
 
+**역할 경계 (#66)**: 이 채널(`HwpUnsupportedDetector`·`unsupportedElements()`)은
+"미지원/복구 요소가 **화면에서** placeholder로 보이는가"다 — 대상이 조판된 쪽에
+실린 요소로 한정된다. "파서가 무엇을 해석하지 못했는가"(조판 무관, ViewText·
+메모·중첩 문단 포함)는 `CoreHwp.HwpFile.parseDiagnostics()`가 맡는다 (루트
+`AGENTS.md` "미해석 요소 집계"). 렌더 스택은 그 API를 소비하지 않는다 — 새
+뷰어 노출을 붙일 때 두 채널을 합치지 말 것.
+
 라인 세그먼트 캐시 (PARA_LINE_SEG)의 `lineLocation`은 페이지 내 절대 y다.
 **실제 줄 전진량 = lineHeight + lineSpacing (per-line 캐시 필드)** — 실측:
 연속 세그먼트의 lineLocation 델타와 일치 (헌법주석 30,345/30,348, noori 전부;

--- a/Sources/HwpKitCore/Layout/HwpUnsupportedDetector.swift
+++ b/Sources/HwpKitCore/Layout/HwpUnsupportedDetector.swift
@@ -3,6 +3,15 @@ import Foundation
 
 /// Classifies a control ID into either "supported" (nil) or an unsupported placeholder element.
 ///
+/// 역할 경계 (#66): Detector가 보는 것은 파스 완전성이 아니라 **조판 결과**다 —
+/// "미지원 요소가 화면에서 placeholder로 보이는가"(뷰어 UI)를 다루고, 실제 수집은
+/// 조판을 구동하는 `HwpPaginator.walkUnsupported`가 하므로 대상은 조판된 쪽에
+/// 실린 컨트롤로 한정된다. 복구 placeholder(`collectRecoveredParseFailures`)와
+/// 컨테이너 깊이 초과도 같은 `.placeholder` 채널로 나간다. 반면 "파서가 무엇을
+/// 해석하지 못했는가"(QA·텔레메트리·버그 리포트·픽스처 회귀 신호)는 조판과
+/// 무관하게 문서 전체 — ViewText·메모·중첩 문단 포함 — 를 집계하는
+/// `CoreHwp.HwpFile.parseDiagnostics()`가 맡는다.
+///
 /// V1 IN (supported, returns nil):
 /// - Text runs (paragraph controls)
 /// - Table, image (picture), footnote, endnote

--- a/Tests/CoreHwpTests/AGENTS.md
+++ b/Tests/CoreHwpTests/AGENTS.md
@@ -165,7 +165,7 @@ payload가 0xFFF 이상이면 size 비트가 level 필드로 넘쳐 헤더가 �
 
 ## 미해석 요소 집계 스위트 (#66)
 
-`HwpFile.parseDiagnostics()`의 kind·path 계약은 세 파일이 잠근다 (합성 빌더는
+`HwpFile.parseDiagnostics()`의 kind·path 계약은 네 파일이 잠근다 (합성 빌더는
 `Models/Document/ParseDiagnosticsTestSupport.swift` 공용, 프레이밍은
 `SectionRecordBuilder` 위임).
 
@@ -175,6 +175,13 @@ payload가 0xFFF 이상이면 size 비트가 level 필드로 넘쳐 헤더가 �
 - `Models/Document/ParseDiagnosticsRecoveryTests.swift` — 복구 placeholder
   3층(구역/문단/메모)의 kind·detail·placeholder 원본 record의 unknownChild
   동반 방출·메모 그룹 path 인덱스를 고정한다.
+- `Models/Document/ParseDiagnosticsFallbackTests.swift` — 제네릭 raw 래퍼로
+  떨어진 승격 실패(`.other` 4종 경로·`.field` 하이퍼링크)가 보고되는지, 그리고
+  **같은 래퍼가 제자리인** 컨트롤(`.bookmark`·정상 `.field`)에는 붙지 않는지를
+  짝으로 고정한다 — 음성 대조군이 없으면 "래퍼면 무조건 보고"라는 오탐 구현도
+  통과한다. 각 테스트가 정말 그 폴백 경로에 떨어졌는지 전제 단언으로 확인하며,
+  구역 정의만 자식을 절단해 넣는다 (자식 부재는 `recordDoesNotExist`라 폴백
+  집합 밖이라 전파된다).
 - `FixtureHarness/FixtureRegression/FixtureParseDiagnosticsTests.swift` —
   픽스처 전수 무크래시·결정성·두 모드 동일성·복구 kind 부재 + manifest의
   `sectionUnknownRecordCount`/`docInfoUnknownRecordCount` 계열 대조 (실제

--- a/Tests/CoreHwpTests/AGENTS.md
+++ b/Tests/CoreHwpTests/AGENTS.md
@@ -163,6 +163,28 @@ payload가 0xFFF 이상이면 size 비트가 level 필드로 넘쳐 헤더가 �
   적대 입력. 뷰어 진단 노출(`kind: .placeholder`)은 `HwpKitCoreTests`의
   `HwpPaginatorRecoveryPlaceholderTests`가 본다.
 
+## 미해석 요소 집계 스위트 (#66)
+
+`HwpFile.parseDiagnostics()`의 kind·path 계약은 세 파일이 잠근다 (합성 빌더는
+`Models/Document/ParseDiagnosticsTestSupport.swift` 공용, 프레이밍은
+`SectionRecordBuilder` 위임).
+
+- `Models/Document/ParseDiagnosticsTests.swift` — 합성 스트림으로 unknown
+  record/control·`.child[i]` 재귀·표 셀 중첩 path·raw 폴백(.notImplemented)
+  컨트롤·ViewText path 분리·`.default`/`.viewer` 동일성을 고정한다.
+- `Models/Document/ParseDiagnosticsRecoveryTests.swift` — 복구 placeholder
+  3층(구역/문단/메모)의 kind·detail·placeholder 원본 record의 unknownChild
+  동반 방출·메모 그룹 path 인덱스를 고정한다.
+- `FixtureHarness/FixtureRegression/FixtureParseDiagnosticsTests.swift` —
+  픽스처 전수 무크래시·결정성·두 모드 동일성·복구 kind 부재 + manifest의
+  `sectionUnknownRecordCount`/`docInfoUnknownRecordCount` 계열 대조 (실제
+  manifest 기대값이 전부 0이라, 합성 manifest + 합성 문서 **양성 대조군**이
+  필터 정규식의 공허화를 막는다). 실저장본 비-공허 앵커는
+  `legacy-common-control-property`의 hiddenComment unknown child 3건이고,
+  track-changes는 실제 BodyText/ViewText stream에 unknown record를 **주입**해
+  두 본문의 진단이 path 접두사로 갈림을 고정한다 (원본 저장본 자체는 진단
+  0건 — 여기서 진단이 생기면 typed 파싱 회귀 신호).
+
 ## 압축 해제 기준선 (#68, #101)
 
 `Streams/Readers/HwpInflateTests.swift`는 두 프로덕션 경로(Apple `Compression`,

--- a/Tests/CoreHwpTests/FixtureHarness/FixtureRegression/FixtureParseDiagnosticsTests.swift
+++ b/Tests/CoreHwpTests/FixtureHarness/FixtureRegression/FixtureParseDiagnosticsTests.swift
@@ -1,0 +1,312 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import OLEKit
+import XCTest
+
+/// `HwpFile.parseDiagnostics()` (#66) — 실저장본 픽스처 전수 게이트.
+///
+/// 전 픽스처 무크래시·결정성·`.default`/`.viewer` 동일성·복구 kind 부재를
+/// 확인하고, manifest의 section/DocInfo unknown record 기대값과 진단 개수를
+/// 대조한다. 실저장본에서 실제 진단이 나오는 비-공허 앵커는
+/// `legacy-common-control-property`의 hiddenComment 계열이다.
+final class FixtureParseDiagnosticsTests: XCTestCase {
+    private static let recoveredKinds: Set<HwpParseDiagnostic.Kind> = [
+        .recoveredSection, .recoveredParagraph, .recoveredMemoParagraph,
+    ]
+
+    func testAllFixturesProduceIdenticalDeterministicDiagnosticsInBothModes() throws {
+        let fixtures = try FixtureLoader.loadAll().filter { $0.manifest.expectedError == nil }
+        expect(fixtures).notTo(beEmpty())
+
+        var totalDiagnosticCount = 0
+        for fixture in fixtures {
+            let fixtureId = fixture.manifest.id
+            let defaultFile = try HwpFile(fromPath: fixture.documentURL.path)
+            let viewerFile = try HwpFile(
+                fromPath: fixture.documentURL.path, options: .viewer
+            )
+            let diagnostics = defaultFile.parseDiagnostics()
+
+            // 결정성: 같은 모델에서 두 번 걸어도 같다.
+            expect(defaultFile.parseDiagnostics()).to(
+                equal(diagnostics),
+                description: "\(fixtureId): diagnostics must be deterministic"
+            )
+            // unknown record payload는 뷰어 모드에서도 분리 복사로 보존되므로
+            // 두 로드 모드의 진단은 같아야 한다.
+            expect(viewerFile.parseDiagnostics()).to(
+                equal(diagnostics),
+                description: "\(fixtureId): default/viewer diagnostics must match"
+            )
+            // 정상 픽스처에서 복구 kind는 절대 나오지 않는다.
+            expect(diagnostics.filter { Self.recoveredKinds.contains($0.kind) }).to(
+                beEmpty(),
+                description: "\(fixtureId): recovered kinds must not fire on healthy fixtures"
+            )
+            // path 접두사 계약 — BodyText/ViewText/DocInfo 셋뿐이다.
+            let invalidPaths = diagnostics.map(\.path).filter { path in
+                !path.hasPrefix("docInfo")
+                    && !path.hasPrefix("section[")
+                    && !path.hasPrefix("viewSection[")
+            }
+            expect(invalidPaths).to(
+                beEmpty(),
+                description: "\(fixtureId): unexpected diagnostic path prefixes"
+            )
+            totalDiagnosticCount += diagnostics.count
+        }
+        // 공허 gate — 실저장본에서 실제 진단이 잡힌다
+        // (legacy-common-control-property의 hiddenComment unknown child 3건 이상).
+        expect(totalDiagnosticCount).to(beGreaterThanOrEqualTo(3))
+    }
+
+    func testSectionAndDocInfoUnknownRecordDiagnosticsMatchManifests() throws {
+        let fixtures = try FixtureLoader.loadAll().filter { $0.manifest.expectedError == nil }
+        var assertedFixtureCount = 0
+
+        for fixture in fixtures {
+            let expectations = fixture.manifest.expectations
+            guard expectations.sectionUnknownRecordCount != nil
+                || expectations.docInfoUnknownRecordCount != nil
+            else {
+                continue
+            }
+            assertedFixtureCount += 1
+            let fixtureId = fixture.manifest.id
+            let diagnostics = try HwpFile(fromPath: fixture.documentURL.path)
+                .parseDiagnostics()
+
+            if let expectedCount = expectations.sectionUnknownRecordCount {
+                let records = diagnostics.filter {
+                    Self.isTopLevelUnknownRecord($0, rootPattern: #"section\[\d+\]\."#)
+                }
+                expect(records.count).to(
+                    equal(expectedCount),
+                    description: "\(fixtureId): section unknown record diagnostic count"
+                )
+                if let expectedTagIds = expectations.sectionUnknownRecordTagIds {
+                    expect(records.compactMap(\.tagId)).to(
+                        equal(expectedTagIds),
+                        description: "\(fixtureId): section unknown record tag ids"
+                    )
+                }
+            }
+            if let expectedCount = expectations.docInfoUnknownRecordCount {
+                let records = diagnostics.filter {
+                    Self.isTopLevelUnknownRecord($0, rootPattern: #"docInfo\."#)
+                }
+                expect(records.count).to(
+                    equal(expectedCount),
+                    description: "\(fixtureId): DocInfo unknown record diagnostic count"
+                )
+                if let expectedTagIds = expectations.docInfoUnknownRecordTagIds {
+                    expect(records.compactMap(\.tagId)).to(
+                        equal(expectedTagIds),
+                        description: "\(fixtureId): DocInfo unknown record tag ids"
+                    )
+                }
+            }
+        }
+        // 공허 gate — unknown record 기대값을 가진 manifest가 실제로 대조됐다.
+        expect(assertedFixtureCount).to(beGreaterThanOrEqualTo(20))
+    }
+
+    func testManifestComparisonFilterDetectsSyntheticUnknownRecords() throws {
+        // 실제 manifest의 unknown record 기대값은 현재 전부 0이라 위 대조가
+        // 0 == 0로만 지나간다 — 필터 정규식이 깨져도 초록이 되지 않도록, 합성
+        // manifest + 합성 문서로 양성 대조군을 둔다
+        // (`FixtureSectionUnknownRecordManifestTests`의 합성 manifest 선례).
+        let manifest = try JSONDecoder().decode(FixtureManifest.self, from: Data("""
+        {
+          "id": "synthetic-parse-diagnostics-positive-control",
+          "generationTool": "synthetic",
+          "hwpVersion": "5.1.0.1",
+          "source": "synthetic",
+          "features": ["unknown-section-record"],
+          "expectations": {
+            "sectionUnknownRecordCount": 1,
+            "sectionUnknownRecordTagIds": [766],
+            "docInfoUnknownRecordCount": 1,
+            "docInfoUnknownRecordTagIds": [761]
+          }
+        }
+        """.utf8))
+        let hwp = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: syntheticControlDocInfoData(),
+            sectionDataArray: [syntheticControlSectionData()]
+        )
+        let diagnostics = hwp.parseDiagnostics()
+
+        let sectionRecords = diagnostics.filter {
+            Self.isTopLevelUnknownRecord($0, rootPattern: #"section\[\d+\]\."#)
+        }
+        // 최상위 unknown record(766)에 child(765)를 달아 두었다 — count가 1이면
+        // `.child[j]` 재귀 진단이 최상위 필터에서 제외됨도 함께 증명된다.
+        expect(sectionRecords.count) == manifest.expectations.sectionUnknownRecordCount
+        expect(sectionRecords.compactMap(\.tagId))
+            == manifest.expectations.sectionUnknownRecordTagIds
+
+        let docInfoRecords = diagnostics.filter {
+            Self.isTopLevelUnknownRecord($0, rootPattern: #"docInfo\."#)
+        }
+        expect(docInfoRecords.count) == manifest.expectations.docInfoUnknownRecordCount
+        expect(docInfoRecords.compactMap(\.tagId))
+            == manifest.expectations.docInfoUnknownRecordTagIds
+    }
+
+    func testLegacyFixtureHiddenCommentUnknownChildrenReportNestedChild() throws {
+        // manifest otherControlSamples의 hiddenComment는 unknownChildTagIds
+        // [72(LIST_HEADER), 66(PARA_HEADER)]와 손자 [68(PARA_CHAR_SHAPE)]를
+        // 보존한다 — 진단이 같은 record를 컨트롤 path 밑에 노출하는지 고정한다.
+        let hwp = try openHwp(#file, "legacy-common-control-property")
+        let diagnostics = hwp.parseDiagnostics()
+
+        let anchor = diagnostics.first { diagnostic in
+            diagnostic.kind == .unknownRecord
+                && diagnostic.tagId == HwpSectionTag.listHeader.rawValue
+                && diagnostic.path.contains(".ctrl[")
+                && diagnostic.path.hasSuffix(".unknownChild[0]")
+        }
+        guard let anchor else {
+            return fail("Expected hiddenComment LIST_HEADER unknown-child diagnostic")
+        }
+        let controlPath = String(anchor.path.dropLast(".unknownChild[0]".count))
+        expect(diagnostics).to(contain(HwpParseDiagnostic(
+            kind: .unknownRecord,
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            path: "\(controlPath).unknownChild[1]"
+        )))
+        expect(diagnostics).to(contain(HwpParseDiagnostic(
+            kind: .unknownRecord,
+            tagId: HwpSectionTag.paraCharShape.rawValue,
+            path: "\(controlPath).unknownChild[1].child[0]"
+        )))
+    }
+
+    func testTrackChangesFixtureSplitsBodyAndViewTextDiagnosticsByPath() throws {
+        // ViewText 픽스처는 track-changes 하나뿐이다 (배포용문서는 expectedError).
+        let url = hwpURL(#file, "track-changes")
+        let original = try HwpFile(fromPath: url.path)
+        expect(original.viewSectionArray.count) == original.sectionArray.count
+        expect(original.viewSectionArray).notTo(beEmpty())
+        // 실측: 이 저장본은 BodyText·ViewText 모두 전부 typed 파싱된다 —
+        // 여기서 진단이 생기면 typed 파싱 회귀 신호다.
+        expect(original.parseDiagnostics()).to(beEmpty())
+
+        // 실제 BodyText/ViewText stream 각각에 서로 다른 unknown record를
+        // 주입해, 두 본문의 진단이 섞이지 않고 path 접두사로 갈리는지 고정한다
+        // (plain-text-minimal raw record 주입 검증과 같은 조립 경로).
+        let ole = try OLEFile(url.path)
+        let reader = StreamReader(
+            ole,
+            try StreamReader.rootStreams(from: ole.root.children)
+        )
+        let isCompressed = original.fileHeader.fileProperty.isCompressed
+        var sectionDataArray = try reader.getDataFromStorage(
+            .bodyText, isCompressed, expectedCount: original.sectionArray.count
+        )
+        let viewTextData = try reader.getOptionalNamedDataFromStorage(
+            .viewText, isCompressed, expectedChildCount: sectionDataArray.count
+        )
+        sectionDataArray[0].append(
+            SectionRecordBuilder.record(tagId: 0x2FE, level: 0, payload: Data([0xB0]))
+        )
+        let injectedViewTextData = viewTextData.map { child in
+            child.name == "Section0"
+                ? (
+                    name: child.name,
+                    data: child.data + SectionRecordBuilder.record(
+                        tagId: 0x2F0, level: 0, payload: Data([0xB1])
+                    )
+                )
+                : child
+        }
+
+        let injected = try HwpFile(
+            fileHeader: original.fileHeader,
+            docInfo: original.docInfo,
+            sectionDataArray: sectionDataArray,
+            viewTextData: injectedViewTextData
+        )
+        expect(injected.viewSectionArray.count) == original.viewSectionArray.count
+        expect(injected.parseDiagnostics()) == [
+            HwpParseDiagnostic(
+                kind: .unknownRecord, tagId: 0x2FE, path: "section[0].unknownRecord[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord, tagId: 0x2F0, path: "viewSection[0].unknownRecord[0]"
+            ),
+        ]
+    }
+}
+
+private extension FixtureParseDiagnosticsTests {
+    /// `<root>unknownRecord[i]` 꼴의 최상위 unknown record 진단인지 —
+    /// `.child[j]` 재귀 진단과 문단 `unknownChild` 진단은 제외한다.
+    static func isTopLevelUnknownRecord(
+        _ diagnostic: HwpParseDiagnostic,
+        rootPattern: String
+    ) -> Bool {
+        diagnostic.kind == .unknownRecord
+            && diagnostic.path.range(
+                of: "^\(rootPattern)unknownRecord\\[\\d+\\]$",
+                options: .regularExpression
+            ) != nil
+    }
+}
+
+// MARK: - 양성 대조군용 합성 스트림 (프레이밍은 SectionRecordBuilder 위임)
+
+/// 최상위 unknown record(766, child 765 포함) + 최소 문단 하나를 가진 구역.
+private func syntheticControlSectionData() -> Data {
+    var data = SectionRecordBuilder.record(tagId: 0x2FE, level: 0, payload: Data([0xCA]))
+    data.append(SectionRecordBuilder.record(tagId: 0x2FD, level: 1, payload: Data([0xFE])))
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: syntheticControlParaHeaderPayload()
+    ))
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+    ))
+    return data
+}
+
+/// 최상위 unknown record(761)를 심은 최소 DocInfo (HwpFileHeader() = 5.1.0.1).
+private func syntheticControlDocInfoData() -> Data {
+    var data = SectionRecordBuilder.record(
+        tagId: HwpDocInfoTag.documentProperties.rawValue,
+        level: 0,
+        payload: concatenatedData(
+            SectionRecordBuilder.littleEndian(UInt16(1)),
+            Data(repeating: 0, count: 24)
+        )
+    )
+    data.append(SectionRecordBuilder.record(
+        tagId: HwpDocInfoTag.idMappings.rawValue,
+        level: 0,
+        payload: Array(repeating: Int32(0), count: 18).reduce(into: Data()) { data, count in
+            data.append(SectionRecordBuilder.littleEndian(count))
+        }
+    ))
+    data.append(SectionRecordBuilder.record(tagId: 0x2F9, level: 0, payload: Data([0x11])))
+    return data
+}
+
+/// PARA_HEADER payload (5.0.3.2 이상 24 byte, 카운트 전부 0).
+private func syntheticControlParaHeaderPayload() -> Data {
+    var data = Data()
+    data.append(SectionRecordBuilder.littleEndian(UInt32(0x8000_0000)))
+    data.append(SectionRecordBuilder.littleEndian(UInt32(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt16(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt8(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt8(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt16(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt16(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt16(0)))
+    data.append(SectionRecordBuilder.littleEndian(UInt32(1)))
+    data.append(SectionRecordBuilder.littleEndian(UInt16(0)))
+    return data
+}

--- a/Tests/CoreHwpTests/Models/Document/ParseDiagnosticsFallbackTests.swift
+++ b/Tests/CoreHwpTests/Models/Document/ParseDiagnosticsFallbackTests.swift
@@ -1,0 +1,185 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// `HwpFile.parseDiagnostics()` (#66) — 제네릭 raw 래퍼로 떨어진 승격 실패의 보고.
+///
+/// `HwpCtrlId.notImplemented`로 떨어지는 표·도형과 달리, 전용 파서가 있는
+/// other/field 계열은 승격에 실패하면 `.other`/`.field`라는 **제네릭 래퍼**로
+/// 보존된다 (`HwpParagraph`의 `columnOrOther`·`listControlOrOther`·
+/// `hyperLinkOrField` 등). 그 래퍼에도 진단이 붙는지, 그리고 같은 래퍼가
+/// **제자리인** 컨트롤에는 붙지 않는지를 짝으로 고정한다 — 음성 대조군이
+/// 없으면 "래퍼면 무조건 보고"라는 오탐 구현도 통과한다.
+final class ParseDiagnosticsFallbackTests: XCTestCase {
+    // MARK: - other 계열: 전용 파서 실패 → .other
+
+    func testColumnPromotionFailureReportsNotImplementedControl() throws {
+        try expectFallbackDiagnostic(ctrlId: HwpOtherCtrlId.column.rawValue)
+    }
+
+    func testSectionDefPromotionFailureReportsNotImplementedControl() throws {
+        // PAGE_DEF(73)를 아예 빼면 `recordDoesNotExist`가 되는데 그것은
+        // `canFallbackToRawControl` 밖이라 폴백이 아니라 전파된다 — 절단한
+        // 자식으로 `truncatedData`를 유도해야 폴백 경로에 닿는다.
+        try expectFallbackDiagnostic(
+            ctrlId: HwpOtherCtrlId.section.rawValue,
+            children: [(tagId: HwpSectionTag.pageDef.rawValue, payload: Data([0x01]))],
+            additionalDiagnostics: [
+                HwpParseDiagnostic(
+                    kind: .unknownRecord,
+                    tagId: HwpSectionTag.pageDef.rawValue,
+                    path: "section[0].paragraph[0].ctrl[0].unknownChild[0]"
+                ),
+            ]
+        )
+    }
+
+    func testPageNumberPositionPromotionFailureReportsNotImplementedControl() throws {
+        try expectFallbackDiagnostic(ctrlId: HwpOtherCtrlId.pageNumberPosition.rawValue)
+    }
+
+    func testHeaderListControlPromotionFailureReportsNotImplementedControl() throws {
+        try expectFallbackDiagnostic(ctrlId: HwpOtherCtrlId.header.rawValue)
+    }
+
+    func testFootnoteListControlPromotionFailureReportsNotImplementedControl() throws {
+        try expectFallbackDiagnostic(ctrlId: HwpOtherCtrlId.footnote.rawValue)
+    }
+
+    // MARK: - field 계열: 하이퍼링크 승격 실패 → .field
+
+    func testHyperlinkPromotionFailureReportsNotImplementedControl() throws {
+        let hwp = try fallbackDocument(ctrlId: HwpFieldCtrlId.hyperLink.rawValue)
+
+        // 전제: 정말 .field 래퍼로 떨어졌는가 (다른 경로를 보고 있으면 무의미)
+        guard case .field = try XCTUnwrap(firstControl(of: hwp)) else {
+            return fail("hyperLink 승격 실패는 .field 래퍼로 폴백해야 한다")
+        }
+        expect(hwp.parseDiagnostics()) == [
+            HwpParseDiagnostic(
+                kind: .notImplementedControl,
+                ctrlId: HwpFieldCtrlId.hyperLink.rawValue,
+                path: "section[0].paragraph[0].ctrl[0]"
+            ),
+        ]
+    }
+
+    // MARK: - 음성 대조군: 같은 래퍼가 제자리인 컨트롤은 보고하지 않는다
+
+    func testGenuineOtherFamilyControlProducesNoControlDiagnostic() throws {
+        // bookmark는 전용 파서가 없어 `otherControl`이 `.bookmark`로 분류한다 —
+        // 승격 실패가 아니므로 진단이 없어야 한다.
+        let hwp = try fallbackDocument(ctrlId: HwpOtherCtrlId.bookmark.rawValue)
+
+        guard case .bookmark = try XCTUnwrap(firstControl(of: hwp)) else {
+            return fail("bookmark는 .bookmark로 분류되어야 한다")
+        }
+        expect(hwp.parseDiagnostics()).to(beEmpty())
+    }
+
+    func testGenuineFieldControlProducesNoControlDiagnostic() throws {
+        // clickHere는 전용 파서가 없어 `.field`가 제자리다 — 같은 래퍼지만
+        // 하이퍼링크와 달리 승격 실패가 아니므로 진단이 없어야 한다.
+        let hwp = try fallbackDocument(ctrlId: HwpFieldCtrlId.clickHere.rawValue)
+
+        guard case .field = try XCTUnwrap(firstControl(of: hwp)) else {
+            return fail("clickHere는 .field로 분류되어야 한다")
+        }
+        expect(hwp.parseDiagnostics()).to(beEmpty())
+    }
+
+    // MARK: - 폴백 진단은 자식 보존과 공존한다
+
+    func testFallbackControlStillReportsPreservedChildren() throws {
+        var data = diagnosticsRecord(
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            level: 0,
+            payload: diagnosticsParaHeaderPayload()
+        )
+        data.append(diagnosticsRecord(
+            tagId: HwpSectionTag.ctrlHeader.rawValue,
+            level: 1,
+            payload: diagnosticsLittleEndianData(HwpOtherCtrlId.column.rawValue)
+        ))
+        data.append(diagnosticsRecord(tagId: 0x2FD, level: 2, payload: Data([0x07])))
+        data.append(diagnosticsRecord(
+            tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+        ))
+
+        let hwp = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: diagnosticsDocInfoData(sectionSize: 1),
+            sectionDataArray: [data]
+        )
+
+        expect(hwp.parseDiagnostics()) == [
+            HwpParseDiagnostic(
+                kind: .notImplementedControl,
+                ctrlId: HwpOtherCtrlId.column.rawValue,
+                path: "section[0].paragraph[0].ctrl[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord,
+                tagId: 0x2FD,
+                path: "section[0].paragraph[0].ctrl[0].unknownChild[0]"
+            ),
+        ]
+    }
+}
+
+private extension ParseDiagnosticsFallbackTests {
+    /// ctrl id 4 byte만 담은 CTRL_HEADER 하나를 가진 최소 문서.
+    /// 전용 파서는 뒤따르는 payload가 없어 `truncatedData` 등으로 실패하고,
+    /// 제네릭 래퍼는 ctrl id만 읽으므로 성공한다.
+    func fallbackDocument(
+        ctrlId: UInt32,
+        children: [(tagId: UInt32, payload: Data)] = []
+    ) throws -> HwpFile {
+        var data = diagnosticsRecord(
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            level: 0,
+            payload: diagnosticsParaHeaderPayload()
+        )
+        data.append(diagnosticsRecord(
+            tagId: HwpSectionTag.ctrlHeader.rawValue,
+            level: 1,
+            payload: diagnosticsLittleEndianData(ctrlId)
+        ))
+        for child in children {
+            data.append(diagnosticsRecord(tagId: child.tagId, level: 2, payload: child.payload))
+        }
+        data.append(diagnosticsRecord(
+            tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+        ))
+        return try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: diagnosticsDocInfoData(sectionSize: 1),
+            sectionDataArray: [data]
+        )
+    }
+
+    func firstControl(of hwp: HwpFile) -> HwpCtrlId? {
+        hwp.sectionArray.first?.paragraph.first?.ctrlHeaderArray?.first
+    }
+
+    /// other 계열 전용 파서의 승격 실패는 전부 `.other` 래퍼로 떨어진다.
+    func expectFallbackDiagnostic(
+        ctrlId: UInt32,
+        children: [(tagId: UInt32, payload: Data)] = [],
+        additionalDiagnostics: [HwpParseDiagnostic] = []
+    ) throws {
+        let hwp = try fallbackDocument(ctrlId: ctrlId, children: children)
+
+        guard case .other = try XCTUnwrap(firstControl(of: hwp)) else {
+            return fail("ctrlId \(ctrlId) 승격 실패는 .other 래퍼로 폴백해야 한다")
+        }
+        expect(hwp.parseDiagnostics()) == [
+            HwpParseDiagnostic(
+                kind: .notImplementedControl,
+                ctrlId: ctrlId,
+                path: "section[0].paragraph[0].ctrl[0]"
+            ),
+        ] + additionalDiagnostics
+    }
+}

--- a/Tests/CoreHwpTests/Models/Document/ParseDiagnosticsRecoveryTests.swift
+++ b/Tests/CoreHwpTests/Models/Document/ParseDiagnosticsRecoveryTests.swift
@@ -1,0 +1,110 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// `HwpFile.parseDiagnostics()` (#66) × 부분 복구 (#65) — 복구 placeholder
+/// 3층(구역·문단·메모 문단)의 kind와 메모 그룹 path 인덱스를 고정한다.
+/// 합성 빌더는 `ParseDiagnosticsTestSupport.swift` 공용이다.
+final class ParseDiagnosticsRecoveryTests: XCTestCase {
+    func testRecoveredPlaceholdersReportAllThreeLayers() throws {
+        let sectionDataArray = [
+            diagnosticsRecoverySectionData(),
+            diagnosticsCorruptSectionData(),
+        ]
+
+        let recovered = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: diagnosticsDocInfoData(sectionSize: 2),
+            sectionDataArray: sectionDataArray,
+            options: .viewer
+        )
+        let diagnostics = recovered.parseDiagnostics()
+
+        let recoveredDiagnostics = diagnostics.filter { $0.kind != .unknownRecord }
+        expect(recoveredDiagnostics.map(\.kind)) == [
+            .recoveredParagraph, .recoveredMemoParagraph, .recoveredSection,
+        ]
+        expect(recoveredDiagnostics.map(\.path)) == [
+            "section[0].paragraph[1]",
+            "section[0].paragraph[2].memo[0].paragraph[1]",
+            "section[1]",
+        ]
+        expect(recoveredDiagnostics[0].detail).to(contain("char shape count mismatch"))
+        expect(recoveredDiagnostics[1].detail).to(contain("char shape count mismatch"))
+        expect(recoveredDiagnostics[2].detail).to(contain("record level 2 has no parent"))
+
+        // placeholder는 원본 레코드를 unknownChildren로 보존하므로 (#65)
+        // 같은 위치에 unknownRecord 진단이 따라 나온다 — 재파싱 근거 노출.
+        expect(diagnostics).to(contain(HwpParseDiagnostic(
+            kind: .unknownRecord,
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            path: "section[0].paragraph[1].unknownChild[0]"
+        )))
+        expect(diagnostics).to(contain(HwpParseDiagnostic(
+            kind: .unknownRecord,
+            tagId: HwpSectionTag.paraCharShape.rawValue,
+            path: "section[0].paragraph[1].unknownChild[0].child[0]"
+        )))
+        expect(diagnostics).to(contain(HwpParseDiagnostic(
+            kind: .unknownRecord,
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            path: "section[0].paragraph[2].memo[0].paragraph[1].unknownChild[0]"
+        )))
+
+        // 보존 모드 + 복구와 뷰어 모드(보존 off + 복구)의 진단은 같다.
+        let preservingRecovered = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: diagnosticsDocInfoData(sectionSize: 2),
+            sectionDataArray: sectionDataArray,
+            options: HwpLoadOptions(recoverPartialContent: true)
+        )
+        expect(preservingRecovered.parseDiagnostics()) == diagnostics
+    }
+
+    func testMultipleMemoGroupsKeepGroupIndexInPath() throws {
+        var host = diagnosticsRecord(
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            level: 0,
+            payload: diagnosticsParaHeaderPayload()
+        )
+        host.append(diagnosticsRecord(
+            tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+        ))
+        host.append(diagnosticsRecord(
+            tagId: HwpSectionTag.memoList.rawValue, level: 1, payload: Data()
+        ))
+        host.append(diagnosticsMemoParagraphData(level: 1))
+        host.append(diagnosticsRecord(
+            tagId: HwpSectionTag.memoList.rawValue, level: 1, payload: Data()
+        ))
+        var secondMemoParagraph = diagnosticsRecord(
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            level: 1,
+            payload: diagnosticsParaHeaderPayload()
+        )
+        secondMemoParagraph.append(diagnosticsRecord(
+            tagId: HwpSectionTag.ctrlHeader.rawValue,
+            level: 2,
+            payload: diagnosticsLittleEndianData(UInt32(0x5A5A_5A5A))
+        ))
+        secondMemoParagraph.append(diagnosticsRecord(
+            tagId: HwpSectionTag.paraCharShape.rawValue, level: 2, payload: Data()
+        ))
+        host.append(secondMemoParagraph)
+
+        let hwp = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: diagnosticsDocInfoData(sectionSize: 1),
+            sectionDataArray: [host]
+        )
+
+        expect(hwp.parseDiagnostics()) == [
+            HwpParseDiagnostic(
+                kind: .unknownControl,
+                ctrlId: 0x5A5A_5A5A,
+                path: "section[0].paragraph[0].memo[1].paragraph[0].ctrl[0]"
+            ),
+        ]
+    }
+}

--- a/Tests/CoreHwpTests/Models/Document/ParseDiagnosticsTestSupport.swift
+++ b/Tests/CoreHwpTests/Models/Document/ParseDiagnosticsTestSupport.swift
@@ -1,0 +1,273 @@
+@testable import CoreHwp
+import Foundation
+
+// `ParseDiagnosticsTests`/`ParseDiagnosticsRecoveryTests`가 공유하는 합성
+// 스트림 빌더 (#66). 레코드 프레이밍은 SectionRecordBuilder가 단일 출처다.
+
+/// 최상위 unknown record(+child), unknown 컨트롤(+child), 문단 unknown
+/// child(+child)를 모두 가진 구역 스트림.
+func diagnosticsUnknownHeavySectionData() -> Data {
+    var data = diagnosticsRecord(tagId: 0x2FE, level: 0, payload: Data([0xCA]))
+    data.append(diagnosticsRecord(tagId: 0x2FD, level: 1, payload: Data([0xAB])))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: diagnosticsParaHeaderPayload()
+    ))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.ctrlHeader.rawValue,
+        level: 1,
+        payload: diagnosticsLittleEndianData(UInt32(0x5858_5858))
+    ))
+    data.append(diagnosticsRecord(tagId: 0x2FC, level: 2, payload: Data([0x01])))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+    ))
+    data.append(diagnosticsRecord(tagId: 0x2FB, level: 1, payload: Data([0x02])))
+    data.append(diagnosticsRecord(tagId: 0x2FA, level: 2, payload: Data([0x03])))
+    return data
+}
+
+/// 정상 문단 하나 + 최상위 unknown record 하나를 가진 최소 구역 스트림.
+func diagnosticsSectionData(unknownTagId: UInt32) -> Data {
+    var data = diagnosticsRecord(tagId: unknownTagId, level: 0, payload: Data([0x77]))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: diagnosticsParaHeaderPayload()
+    ))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+    ))
+    return data
+}
+
+/// [정상 문단, 손상 문단(문단 placeholder), 메모 호스트(손상 메모 문단 포함)]
+/// 구역 — 복구 모드에서 recoveredParagraph·recoveredMemoParagraph를 만든다.
+func diagnosticsRecoverySectionData() -> Data {
+    var data = diagnosticsValidParagraphData(level: 0)
+    data.append(diagnosticsCorruptParagraphData(level: 0))
+
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: diagnosticsParaHeaderPayload()
+    ))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+    ))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.memoList.rawValue, level: 1, payload: Data()
+    ))
+    data.append(diagnosticsMemoParagraphData(level: 1))
+    data.append(diagnosticsCorruptParagraphData(level: 1))
+    return data
+}
+
+/// 레코드 트리 구조 자체가 깨진 구역 — HwpFile 조립이 구역 단위 placeholder로
+/// 승격한다 (`record level 2 has no parent`).
+func diagnosticsCorruptSectionData() -> Data {
+    diagnosticsRecord(tagId: 0x2FE, level: 2, payload: Data([0xAA]))
+}
+
+func diagnosticsValidParagraphData(level: UInt32) -> Data {
+    var data = diagnosticsRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: level,
+        payload: diagnosticsParaHeaderPayload(charCount: 1, charShapeInfoCount: 1)
+    )
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraText.rawValue,
+        level: level + 1,
+        payload: diagnosticsLittleEndianData(WCHAR(0xAC00))
+    ))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraCharShape.rawValue,
+        level: level + 1,
+        payload: diagnosticsCharShapePairPayload()
+    ))
+    return data
+}
+
+func diagnosticsMemoParagraphData(level: UInt32) -> Data {
+    var data = diagnosticsRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: level,
+        payload: diagnosticsParaHeaderPayload()
+    )
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: level + 1, payload: Data()
+    ))
+    return data
+}
+
+/// charShapeInfoCount(2)와 실제 PARA_CHAR_SHAPE 항목 수(1)가 어긋난 손상 문단.
+func diagnosticsCorruptParagraphData(level: UInt32) -> Data {
+    var data = diagnosticsRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: level,
+        payload: diagnosticsParaHeaderPayload(charShapeInfoCount: 2)
+    )
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraCharShape.rawValue,
+        level: level + 1,
+        payload: diagnosticsCharShapePairPayload()
+    ))
+    return data
+}
+
+/// PARA_HEADER payload (HwpFileHeader() 기본 5.1.0.1 — 5.0.3.2 이상 24 byte).
+func diagnosticsParaHeaderPayload(
+    charCount: UInt32 = 0,
+    charShapeInfoCount: UInt16 = 0
+) -> Data {
+    var data = Data()
+    data.append(diagnosticsLittleEndianData(charCount | 0x8000_0000))
+    data.append(diagnosticsLittleEndianData(UInt32(0)))
+    data.append(diagnosticsLittleEndianData(UInt16(0)))
+    data.append(diagnosticsLittleEndianData(UInt8(0)))
+    data.append(diagnosticsLittleEndianData(UInt8(0)))
+    data.append(diagnosticsLittleEndianData(charShapeInfoCount))
+    data.append(diagnosticsLittleEndianData(UInt16(0)))
+    data.append(diagnosticsLittleEndianData(UInt16(0)))
+    data.append(diagnosticsLittleEndianData(UInt32(1)))
+    data.append(diagnosticsLittleEndianData(UInt16(0)))
+    return data
+}
+
+func diagnosticsCharShapePairPayload() -> Data {
+    concatenatedData(
+        diagnosticsLittleEndianData(UInt32(0)),
+        diagnosticsLittleEndianData(UInt32(0))
+    )
+}
+
+/// 1×1 표 컨트롤 안에 unknown record와 unknown 컨트롤을 가진 셀 문단을 심은
+/// 구역 스트림 — 셀 path 재귀 검증용.
+func diagnosticsTableSectionData() -> Data {
+    var cellParagraph = diagnosticsRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 2,
+        payload: diagnosticsParaHeaderPayload()
+    )
+    cellParagraph.append(diagnosticsRecord(
+        tagId: HwpSectionTag.ctrlHeader.rawValue,
+        level: 3,
+        payload: diagnosticsLittleEndianData(UInt32(0x5959_5959))
+    ))
+    cellParagraph.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: 3, payload: Data()
+    ))
+
+    var data = diagnosticsRecord(
+        tagId: HwpSectionTag.paraHeader.rawValue,
+        level: 0,
+        payload: diagnosticsParaHeaderPayload()
+    )
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.ctrlHeader.rawValue,
+        level: 1,
+        payload: diagnosticsTableCommonCtrlPropertyPayload()
+    ))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.table.rawValue,
+        level: 2,
+        payload: diagnosticsTablePropertyPayload(rowCount: 1, columnCount: 1)
+    ))
+    data.append(diagnosticsRecord(tagId: 0x2FE, level: 2, payload: Data([0xEE])))
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.listHeader.rawValue,
+        level: 2,
+        payload: diagnosticsTableCellHeaderPayload(paragraphCount: 1)
+    ))
+    data.append(cellParagraph)
+    data.append(diagnosticsRecord(
+        tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+    ))
+    return data
+}
+
+/// 표 컨트롤 CTRL_HEADER payload — 개체 공통 속성 46 byte
+/// (`TableControlStabilityTests`의 레이아웃과 동일).
+func diagnosticsTableCommonCtrlPropertyPayload() -> Data {
+    var data = Data()
+    data.append(diagnosticsLittleEndianData(HwpCommonCtrlId.table.rawValue))
+    data.append(diagnosticsLittleEndianData(UInt32(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT(0)))
+    data.append(diagnosticsLittleEndianData(Int32(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT16(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT16(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT16(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT16(0)))
+    data.append(diagnosticsLittleEndianData(UInt32(0)))
+    data.append(diagnosticsLittleEndianData(Int32(0)))
+    data.append(diagnosticsLittleEndianData(WORD(0)))
+    return data
+}
+
+func diagnosticsTablePropertyPayload(rowCount: UInt16, columnCount: UInt16) -> Data {
+    var data = Data()
+    data.append(diagnosticsLittleEndianData(UInt32(0)))
+    data.append(diagnosticsLittleEndianData(rowCount))
+    data.append(diagnosticsLittleEndianData(columnCount))
+    data.append(diagnosticsLittleEndianData(HWPUNIT16(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT16(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT16(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT16(0)))
+    data.append(diagnosticsLittleEndianData(HWPUNIT16(0)))
+    for _ in 0 ..< rowCount {
+        data.append(diagnosticsLittleEndianData(UInt16(0)))
+    }
+    data.append(diagnosticsLittleEndianData(UInt16(0)))
+    data.append(diagnosticsLittleEndianData(UInt16(0)))
+    return data
+}
+
+func diagnosticsTableCellHeaderPayload(paragraphCount: UInt16) -> Data {
+    var data = Data()
+    data.append(diagnosticsLittleEndianData(paragraphCount))
+    data.append(diagnosticsLittleEndianData(UInt32(0)))
+    data.append(diagnosticsLittleEndianData(UInt16(0)))
+    data.append(Data(repeating: 0, count: 39))
+    return data
+}
+
+/// HwpFile 조립 최소 DocInfo — 필요하면 최상위 unknown record(+child)를 심는다.
+func diagnosticsDocInfoData(
+    sectionSize: UInt16,
+    includeUnknownRecord: Bool = false
+) -> Data {
+    var data = concatenatedData(
+        diagnosticsRecord(
+            tagId: HwpDocInfoTag.documentProperties.rawValue,
+            level: 0,
+            payload: concatenatedData(
+                diagnosticsLittleEndianData(sectionSize),
+                Data(repeating: 0, count: 24)
+            )
+        ),
+        diagnosticsRecord(
+            tagId: HwpDocInfoTag.idMappings.rawValue,
+            level: 0,
+            payload: Array(repeating: Int32(0), count: 18).reduce(into: Data()) { data, count in
+                data.append(diagnosticsLittleEndianData(count))
+            }
+        )
+    )
+    if includeUnknownRecord {
+        data.append(diagnosticsRecord(tagId: 0x2F9, level: 0, payload: Data([0x11])))
+        data.append(diagnosticsRecord(tagId: 0x2F8, level: 1, payload: Data([0x22])))
+    }
+    return data
+}
+
+func diagnosticsRecord(tagId: UInt32, level: UInt32, payload: Data) -> Data {
+    SectionRecordBuilder.record(tagId: tagId, level: level, payload: payload)
+}
+
+func diagnosticsLittleEndianData(_ value: some FixedWidthInteger) -> Data {
+    SectionRecordBuilder.littleEndian(value)
+}

--- a/Tests/CoreHwpTests/Models/Document/ParseDiagnosticsTests.swift
+++ b/Tests/CoreHwpTests/Models/Document/ParseDiagnosticsTests.swift
@@ -1,0 +1,165 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// `HwpFile.parseDiagnostics()` (#66) — 미해석 요소 집계의 kind·path 계약.
+///
+/// 합성 스트림으로 unknown record/control의 위치 표기, 중첩 컨트롤(표 셀) 재귀,
+/// raw 폴백(.notImplemented) 컨트롤, ViewText/BodyText의 path 분리,
+/// `.default`/`.viewer` 두 모드의 진단 동일성을 고정한다. 복구 placeholder
+/// 3층은 `ParseDiagnosticsRecoveryTests`가 잠근다. 합성 빌더는
+/// `ParseDiagnosticsTestSupport.swift` 공용이다.
+final class ParseDiagnosticsTests: XCTestCase {
+    // MARK: - unknown record·control·child 재귀의 kind와 path
+
+    func testUnknownRecordsControlsAndChildrenReportKindAndPath() throws {
+        let hwp = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: diagnosticsDocInfoData(sectionSize: 1, includeUnknownRecord: true),
+            sectionDataArray: [diagnosticsUnknownHeavySectionData()]
+        )
+
+        expect(hwp.parseDiagnostics()) == [
+            HwpParseDiagnostic(
+                kind: .unknownRecord, tagId: 0x2F9, path: "docInfo.unknownRecord[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord, tagId: 0x2F8, path: "docInfo.unknownRecord[0].child[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord, tagId: 0x2FE, path: "section[0].unknownRecord[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord, tagId: 0x2FD, path: "section[0].unknownRecord[0].child[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord,
+                tagId: 0x2FB,
+                path: "section[0].paragraph[0].unknownChild[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord,
+                tagId: 0x2FA,
+                path: "section[0].paragraph[0].unknownChild[0].child[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownControl,
+                ctrlId: 0x5858_5858,
+                path: "section[0].paragraph[0].ctrl[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord,
+                tagId: 0x2FC,
+                path: "section[0].paragraph[0].ctrl[0].unknownChild[0]"
+            ),
+        ]
+    }
+
+    func testDefaultAndViewerModesProduceIdenticalDiagnostics() throws {
+        // unknown record payload는 뷰어 모드에서도 비워지지 않고 분리 복사되므로
+        // (`HwpUnknownRecord` 진단 시맨틱 보존) 두 모드의 진단은 같아야 한다.
+        let docInfoData = diagnosticsDocInfoData(sectionSize: 1, includeUnknownRecord: true)
+        let sectionData = diagnosticsUnknownHeavySectionData()
+
+        let defaultDiagnostics = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: docInfoData,
+            sectionDataArray: [sectionData]
+        ).parseDiagnostics()
+        let viewerDiagnostics = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: docInfoData,
+            sectionDataArray: [sectionData],
+            options: .viewer
+        ).parseDiagnostics()
+
+        expect(defaultDiagnostics).notTo(beEmpty())
+        expect(viewerDiagnostics) == defaultDiagnostics
+    }
+
+    // MARK: - 중첩 표 셀 문단 재귀
+
+    func testNestedTableUnknownsReportCellPaths() throws {
+        let hwp = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: diagnosticsDocInfoData(sectionSize: 1),
+            sectionDataArray: [diagnosticsTableSectionData()]
+        )
+
+        expect(hwp.parseDiagnostics()) == [
+            HwpParseDiagnostic(
+                kind: .unknownRecord,
+                tagId: 0x2FE,
+                path: "section[0].paragraph[0].ctrl[0].unknownChild[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownControl,
+                ctrlId: 0x5959_5959,
+                path: "section[0].paragraph[0].ctrl[0].cell[0].paragraph[0].ctrl[0]"
+            ),
+        ]
+    }
+
+    func testNotImplementedControlFallbackReportsKindAndChildren() throws {
+        // 알려진 ctrl id(표)지만 payload를 ctrl id 4 byte로 절단해 typed 파싱이
+        // truncatedData로 실패하면 raw 폴백(.notImplemented)이 된다 — 이때
+        // ctrl 전체가 미해석이므로 child record도 unknownChild로 나와야 한다.
+        var data = diagnosticsRecord(
+            tagId: HwpSectionTag.paraHeader.rawValue,
+            level: 0,
+            payload: diagnosticsParaHeaderPayload()
+        )
+        data.append(diagnosticsRecord(
+            tagId: HwpSectionTag.ctrlHeader.rawValue,
+            level: 1,
+            payload: diagnosticsLittleEndianData(HwpCommonCtrlId.table.rawValue)
+        ))
+        data.append(diagnosticsRecord(tagId: 0x2FD, level: 2, payload: Data([0x05])))
+        data.append(diagnosticsRecord(
+            tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()
+        ))
+
+        let hwp = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: diagnosticsDocInfoData(sectionSize: 1),
+            sectionDataArray: [data]
+        )
+
+        expect(hwp.parseDiagnostics()) == [
+            HwpParseDiagnostic(
+                kind: .notImplementedControl,
+                ctrlId: HwpCommonCtrlId.table.rawValue,
+                path: "section[0].paragraph[0].ctrl[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord,
+                tagId: 0x2FD,
+                path: "section[0].paragraph[0].ctrl[0].unknownChild[0]"
+            ),
+        ]
+    }
+
+    // MARK: - ViewText 표시본은 path 접두사로 갈린다
+
+    func testViewTextDiagnosticsSplitByPathPrefix() throws {
+        let hwp = try HwpFile(
+            fileHeader: HwpFileHeader(),
+            docInfoData: diagnosticsDocInfoData(sectionSize: 1),
+            sectionDataArray: [diagnosticsSectionData(unknownTagId: 0x2FE)],
+            viewTextData: [
+                (name: "Section0", data: diagnosticsSectionData(unknownTagId: 0x2F0)),
+            ]
+        )
+
+        expect(hwp.viewSectionArray.count) == 1
+        expect(hwp.parseDiagnostics()) == [
+            HwpParseDiagnostic(
+                kind: .unknownRecord, tagId: 0x2FE, path: "section[0].unknownRecord[0]"
+            ),
+            HwpParseDiagnostic(
+                kind: .unknownRecord, tagId: 0x2F0, path: "viewSection[0].unknownRecord[0]"
+            ),
+        ]
+    }
+}

--- a/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphMemoRecursionTests.swift
+++ b/Tests/CoreHwpTests/Stability/Paragraphs/ParagraphMemoRecursionTests.swift
@@ -69,6 +69,33 @@ final class ParagraphMemoRecursionTests: XCTestCase {
         expect(paragraph.memoParagraphGroups?.count) == 1
         expect(paragraph.memoParagraphGroups?.first).to(beEmpty())
         expect(paragraph.memoParagraphArray).to(beNil())
+        // MEMO_LIST는 빈 그룹으로 typed 소비됐으므로 unknownChildren에
+        // 중복 보존되지 않는다 (#66 — 소비 인덱스 기반 제외).
+        expect(paragraph.unknownChildren).to(beEmpty())
+    }
+
+    func testStrayParagraphBeforeFirstMemoListIsPreservedAsUnknownChild() throws {
+        // 첫 MEMO_LIST 앞의 문단(66) child는 그룹 빌더가 소비하지 않는다
+        // (current == nil). 태그 blanket 제외 시절에는 이 record가 typed 소비도
+        // raw 보존도 없이 모델에서 사라져 미해석 집계(#66)가 볼 수 없었다 —
+        // 소비 인덱스 기반 제외로 unknownChildren에 남는지 고정한다.
+        let host = memoHostParagraphRecord(children: [
+            HwpRecord(tagId: HwpSectionTag.paraCharShape.rawValue, level: 1, payload: Data()),
+            HwpRecord(tagId: HwpSectionTag.paraLineSeg.rawValue, level: 1, payload: Data()),
+            memoParagraphRecord(text: 0xAC00),
+            HwpRecord(tagId: HwpSectionTag.memoList.rawValue, level: 1, payload: Data()),
+            memoParagraphRecord(text: 0xB098),
+        ])
+
+        let paragraph = try HwpParagraph.load(host, version)
+
+        expect(paragraph.memoParagraphGroups?.count) == 1
+        expect(
+            paragraph.memoParagraphGroups?.first?
+                .map { $0.paraText?.charArray.map(\.value) ?? [] }
+        ) == [[0xB098]]
+        expect(paragraph.unknownChildren.count) == 1
+        expect(paragraph.unknownChildren.first?.tagId) == HwpSectionTag.paraHeader.rawValue
     }
 
     func testCorruptMemoParagraphThrowsTypedErrorInDefaultMode() {


### PR DESCRIPTION
Closes #66

## 요약

파서는 해석하지 못한 요소를 버리지 않고 보존한다 — 구역·DocInfo의 `unknownRecords`, 모델 곳곳의 `unknownChildren`, `HwpCtrlId`의 `.notImplemented`/`.unknown`, 전용 타입으로 승격하지 못해 남은 제네릭 `.other`/`.field` 래퍼가 그 예다. 하지만 이를 문서 단위로 집계하는 공개 API가 없어, 호스트가 "이 문서에서 파서가 무엇을 해석하지 못했는지" 확인하려면 필드를 직접 훑어야 했다. `HwpFile.parseDiagnostics()`가 이 역할을 맡는다. `HwpFile`의 첫 `extension`이다.

렌더 스택의 `HwpUnsupportedDetector`와는 **관점이 다르다**. `HwpUnsupportedDetector`는 "미지원 요소가 **화면에서** placeholder로 보이는가"를 판단하므로 조판된 페이지에 포함된 컨트롤만 대상으로 삼는다. `parseDiagnostics()`는 "**파서가** 무엇을 해석하지 못했는가"를 기준으로, 조판 여부와 관계없이 ViewText·메모·중첩 문단까지 순회한다. 용도는 QA·텔레메트리·버그 리포트·픽스처 회귀 신호다.

## 구현

- **`HwpParseDiagnostic`** (`Sources/CoreHwp/Models/HwpParseDiagnostic.swift`, 신규) — `kind` + `tagId`/`ctrlId` + `path` + `detail`. `kind` 6종은 `unknownRecord`·`unknownControl`·`notImplementedControl`·`recoveredSection`·`recoveredParagraph`·`recoveredMemoParagraph`다. `HwpFile.swift`에 공개 타입을 직접 두지 않는 규약에 따라 `Models/` 하위 새 파일에 둔다.
- **`HwpFile.parseDiagnostics()`** — DocInfo → `sectionArray` → `viewSectionArray` 순으로 순회한다. 두 본문은 `section[i]` / `viewSection[i]` `path` 접두사로 구분한다. 렌더 본문 선택(`displaySectionArray`)과 달리 **채택되지 않은 표시본도** 순회한다 — 그 표시본이 담고 있던 내용도 진단 대상이기 때문이다.
  - 컨트롤은 표 셀·리스트 4종(머리말·꼬리말·각주·미주)·글상자·shape component detail 16종·`ctrlData`까지 재귀적으로 순회한다. 메모는 `memo[g].paragraph[m]` 경로에 그룹 인덱스를 넣어 개별 메모를 식별한다.
  - 컨트롤 진단은 `.unknown`/`.notImplemented`뿐 아니라, 전용 타입으로 승격하지 못해 제네릭 `.other`/`.field` 래퍼로 남은 경우도 포함한다. `.other`는 그 자체로 폴백의 증거이고, `.field`는 `ctrlId == .hyperLink`일 때만 폴백으로 판단해 정상 field 컨트롤을 오탐하지 않는다.
  - **`HwpCtrlId` switch는 `default:` 없이 모든 case를 열거한다.** 새 컨트롤 case가 추가되면 컴파일러가 진단 순회 누락을 강제로 잡는다. `HwpUnsupportedDetector.unsupportedHint`와 같은 규칙이고, 현재 저장소에서 `HwpCtrlId`를 전수 검사하는 switch는 이 둘뿐이다.
  - **이중 보고를 막는 별칭 규칙** — `HwpShapeControl.eqEditRecords`와 `HwpShapeComponent.oleRecords`는 typed 배열에 대응하는 raw 사본이고, `HwpListControl.header.unknownChildren`는 `HwpCtrlHeader.load`가 typed로 소비한 리스트·문단까지 모두 raw로 담은 필드다. DocInfo 결합 배열에서 idMappings·docData가 소유한 구간도 각자의 경로에서 이미 보고한다. 최상위 `layoutCompatibility`는 `compatibleDocument` 자식의 폴백 별칭일 수 있어 값이 같으면 건너뛴다. 반대로 `.unknown`/`.notImplemented` 컨트롤의 `header.unknownChildren`는 **순회한다** — 그 컨트롤은 아무것도 typed로 소비하지 않았기 때문이다.
  - **순서는 결정적이다.** 컨테이너는 문서 순서로 순회하고, 컨테이너 안에서는 종류별 그룹 순서를 따른다. 파싱 단계에서 레코드를 종류별 배열로 나누면서 원본 스트림의 교차 배치 순서를 잃으므로, 순회 단계에서는 그 이상 복원할 수 없다.
  - **복구가 개입하지 않는 입력에서는 `.default`와 `.viewer`의 진단 결과가 같다.** `preserveRawPayload`가 꺼져 있어도 `HwpUnknownRecord`가 payload를 별도로 복사해 보존하기 때문이다.
  - 순회 로직에는 자체 깊이 상한을 두지 않는다. 파싱 시점에 `maxNestingDepth`(#64)가 이미 트리 깊이를 제한한다.
- **`HwpUnsupportedDetector` 역할 경계 문서 주석** (`Sources/HwpKitCore/Layout/HwpUnsupportedDetector.swift`) — 이슈에서 요구한 항목이다. 기존 문서 주석은 "V1 IN" / "V1 OUT" / "보고하지 않는 컨트롤" 세 목록뿐이라 두 API의 역할을 구분하는 문장이 없었다. `HwpPaginator`가 복구 placeholder와 컨테이너 깊이 초과까지 같은 `.placeholder` 채널로 내보내면서 경계도 더 흐려진 상태였다. 렌더 스택은 `parseDiagnostics()`를 사용하지 않는다.
- **관련 수정 — 메모 계열 자식 레코드의 소비 여부를 실제로 소비한 인덱스를 기준으로 판단하도록 바꿨다** (`HwpParagraph.unconsumedRecords`). 기존에는 태그만 보고 일괄 제외했다. 표준 저장본 레이아웃(`MEMO_LIST` 뒤 문단)의 동작은 그대로다. 자세한 결함은 아래와 같다.

## 리뷰 반영

구현 후 이중 보고, 순회 범위, 결정성을 검토해 세 가지를 반영했다.

1. **메모 계열 소비 판정의 두 가지 결함** — 진단 API가 아니라 **파서**의 결함이었다. 첫 `MEMO_LIST` 앞의 독립 `PARA_HEADER`(tag ID 66)는 그룹 빌더가 소비하지 않는데(`current == nil`) 태그만 보고 일괄 제외되어, typed 모델로 소비되지도 raw 레코드로 보존되지도 않은 채 사라졌다. 집계 로직이 **구조상 발견할 수 없는** 유실이라 진단 로직만 고쳐서는 드러나지 않는다. 반대로 문단 없는 `MEMO_LIST`는 빈 그룹으로 typed 소비됐는데도 `unknownChildren`에 중복 보존됐다. 그룹 빌더가 실제로 소비한 자식 레코드 인덱스 집합을 넘겨 두 문제를 함께 해결했다. **회귀 테스트**: `ParagraphMemoRecursionTests`에 독립 문단이 `unknownChildren`에 남는지 검증하는 테스트를 추가하고, 빈 그룹이 중복 보존되지 않음을 기존 테스트에 단언으로 더했다.
2. **manifest 검증이 아무것도 확인하지 않고 통과할 수 있었다** — 실제 저장본 manifest의 unknown record 기대값이 모두 0이라 검증이 `0 == 0`만 확인했다. 이 상태에서는 필터 정규식이 깨져도 테스트가 통과할 수 있다. 합성 manifest와 합성 문서로 **양성 대조군**(`testManifestComparisonFilterDetectsSyntheticUnknownRecords`)을 두어 막았다. 실제 저장본에서 0이 아닌 대조 값은 `legacy-common-control-property`의 hiddenComment unknown child 3건이다.
3. **제네릭 래퍼로 보존된 승격 실패가 누락됐다** — 표·도형은 typed 승격에 실패하면 `.notImplemented`로 떨어지지만, `other`/`field` 계열은 제네릭 `.other`/`.field` 래퍼로 남는다. 기존 순회는 이 래퍼의 자식만 확인해, 자식이 없는 폴백은 진단을 하나도 남기지 않았다. `.other`는 도달 자체를 폴백으로 판단하고, `.field`는 `ctrlId == .hyperLink`일 때만 폴백으로 판단하도록 고쳤다. `ParseDiagnosticsFallbackTests` 9종이 폴백 경로, 정상 컨트롤 대조군, 보존된 자식과의 공존을 검증한다.

## 검증 게이트(#66)

- [x] 합성 입력(unknown 컨트롤 · unknown 자식 · 중첩 표 안 unknown · 복구 placeholder · 제네릭 래퍼 폴백)의 `kind`·`path` 정확성 — `ParseDiagnosticsTests` 5종 + `ParseDiagnosticsRecoveryTests` 2종 + `ParseDiagnosticsFallbackTests` 9종. 손상 입력 구성에는 `SectionRecordBuilder`를 재사용한다
- [x] ViewText 픽스처(`track-changes`)에서 BodyText 진단과 ViewText 진단이 `path`로 구분됨 — `testTrackChangesFixtureSplitsBodyAndViewTextDiagnosticsByPath`. 이 저장본은 원본 그대로는 진단이 0건이므로(여기서 진단이 나오면 typed 파싱 회귀 신호다), 테스트에서 BodyText와 ViewText 스트림에 서로 다른 unknown record를 주입해 구분을 고정한다
- [x] 픽스처 파싱이 비정상 종료 없이 완료되고 manifest 기대값과 일치함 — **33종 중 29종**. `expectedError` 4종(암호 2 · 배포용 · DRM)은 파싱 자체가 `unsupportedFeature`로 실패해 진단 순회에 도달하지 못하므로 제외했다. 위 양성 대조군으로 검증이 아무것도 확인하지 않고 통과하는 상황을 막았다
- [x] 복구가 개입하지 않는 `.default` / `.viewer` 두 모드의 진단 결과 동일 — 합성 입력(`testDefaultAndViewerModesProduceIdenticalDiagnostics`)과 정상 픽스처 29종에서 각각 단언
- [x] 복구 진단 3층 — 구역·문단·메모 placeholder가 각각 `recoveredSection` / `recoveredParagraph` / `recoveredMemoParagraph`로 잡힌다(`testRecoveredPlaceholdersReportAllThreeLayers`). 메모 그룹 인덱스는 `testMultipleMemoGroupsKeepGroupIndexInPath`로 검증한다

## 실측

- macOS CI `swift test --enable-code-coverage`: **2,233 tests, 3 skipped, 0 failures** (신규 22종 포함). 렌더 경로를 건드리지 않아 커밋된 기준선 4종(블록 좌표 스냅샷 · 잉크 골든 · 페이지 수 · 각주 겹침)도 그대로 통과했다 — 이들은 기본 `swift test`에서 함께 실행된다
- 커버리지(CI와 같은 lcov 산술): `Sources/CoreHwp/` **97.46%** (8554/8777, 게이트 95.0) · `Sources/HwpKitCore/` **93.43%** (13879/14855, 게이트 91.0). Codecov의 PR patch coverage는 **97.64%**이고, `HwpParseDiagnostic.swift`의 patch coverage는 **97.56%**(미커버 7줄)다
- `swiftformat --lint` 0/651 · `swiftlint` 오류 0
- 변경 규모 15개 파일, +1,719 / −11

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
