### PR TITLE
refactor(layout): HwpPage 동등성 및 PaintListBuilder API 단순화, Paginator 구조 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -539,8 +539,9 @@ noori p2에서 비영 셀의 30%까지 지워도 양쪽 통과).
 
 사이드바·목차가 "그 자리로 간다"를 하려면 **쪽**을 알아야 하고 쪽은 조판의
 함수다 — 그래서 수집기가 파서가 아니라 `HwpPaginator` 옆에 산다
-(`Sources/HwpKitCore/Layout/Paginator/HwpOutlineCollector.swift`, 본체는
-2,800줄이고 swiftlint `file_length` error가 700이라 새 파일이 필수다).
+(`Sources/HwpKitCore/Layout/Paginator/HwpOutlineCollector.swift`, 본체
+`HwpPaginator`가 swiftlint `file_length` error 상한(700)을 훨씬 넘겨 새 파일이
+필수다).
 결과는 `HwpDocumentMetadata.outline: [HwpOutlineItem]`이다.
 
 - **문단 수준은 0-기반 저장값이다** (표 44 bit 25-27,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 ### Breaking Changes
 
+- `HwpPaintListBuilder.build(for:index:)` **에서 `index:` 인자가 제거되었습니다.**
+  이 인자는 도입 이래 한 번도 읽히지 않았습니다 — 412줄 구현 전체에서 `index`가
+  등장하는 곳이 시그니처 한 줄뿐이었습니다.
+  - *이행*: 호출부에서 `index:` 인자만 지우면 됩니다
+    (`builder.build(for: page, index: someIndex)` → `builder.build(for: page)`).
+    넘기던 `HwpIndex`를 다른 데 쓰지 않았다면 그 값도 함께 죽습니다.
+
+- **`HwpPage`의 `==`/`hash`가 더 이상 `paintList`를 보지 않습니다.** 종전에는
+  본문과 메모 패널의 `paintList.commands.count`를 항으로 들고 있었습니다. 이제
+  `size`·`margins`·`blocks`·`pageNumber`와 메모 패널 기하(`width`·`contentHeight`)
+  로만 판정합니다. 소스 브레이킹은 아니지만 **동작이 바뀝니다.**
+  - 본문 paint 커맨드는 `blocks`의 파생값이라 판별력을 더하지 못했고, CF
+    페이로드(`NSAttributedString`/`CGImage`/`CGPath`/`CGColor`)는 Equatable이
+    아니라 애초에 개수 말고는 비교할 수단도 없었습니다.
+  - *영향*: 커맨드 수만 다른 두 페이지가 이제 **같다고** 판정됩니다. 이 동등성은
+    렌더 갱신 스킵뿐 아니라 선택 지오메트리 재생성과 검색 재스캔 생략
+    (`HwpGeometryChange.isEquivalentRefresh`)의 입력이므로, 그런 재전달에서
+    재스캔이 생략되고 지오메트리 재생성이 건너뛰어집니다. 조판 구조가 같으면
+    지오메트리도 같으므로 의도된 개선입니다.
+  - 렌더 결과가 다른지 확인하는 데 `HwpPage.==`를 쓰던 코드는 `blocks`나
+    `paintList.commands`를 직접 순회해야 합니다 — 종전에도 커맨드 **개수**만
+    맞으면 통과했으므로 신뢰할 수 없는 방법이었습니다.
+
 - `HwpParagraphLayout.layout(attributedString:paraShape:columnWidth:tabStops:maxLineFrames:)`
   에서 **`tabStops:` 인자가 제거되었습니다.** 이 함수는 이제 입력
   `attributedString`에 **문단 스타일이 이미 부착돼 있다고 전제하고** 그것을 그대로
@@ -103,6 +126,24 @@
   의존을 선언해야 합니다.
 
 ### Changed
+
+- **개체 앵커 산식의 소유자를 일원화했습니다** (#73). 페이지 흐름 경로
+  (`HwpPaginator`)와 컨테이너 안 수집 경로(`HwpParagraphObjectCollector`)가
+  정렬 반영 좌표와 글자처럼 취급 개체의 줄 앵커 좌표를 각자 구현하고 "같은
+  산식"이라는 주석으로만 묶여 있던 것을 `HwpObjectAnchorGeometry`(internal)로
+  합쳤습니다. 산식은 한 글자도 바뀌지 않았고 렌더 픽셀도 무변화입니다.
+  컨테이너 경로의 `origin(...)`은 페이지 경로의 **문단 rect 근사**라 같은
+  함수가 아니므로 합치지 않았습니다.
+- `HwpPaginator.computeNextPage`를 `processParagraph` / `measuredParagraph` /
+  `finishPagination` 셋으로 나눴습니다 (#73). 동작은 같고, 이 파일의
+  `function_body_length` 위반이 5건에서 4건으로 줄었습니다.
+- **문단마다 최대 두 번 돌던 `Task.yield()`를 16문단마다 한 번으로 배칭했습니다**
+  (#73). 20,000문단 문서 기준 최대 40,000회이던 스케줄러 왕복이 2,500회가
+  됩니다. 취소 **관찰**은 이 배칭과 독립입니다 — `processParagraph`가 문단마다
+  `Task.checkCancellation()`을 그대로 부르며, 신설
+  `HwpPaginatorCancellationTests`가 그 분리를 잠급니다.
+- 변경 추적 표시색이 두 곳(`HwpTextRunBuilderMarks`·`HwpPaginator`)에
+  하드코딩돼 있던 것을 `CGColor.hwpTrackChange` 하나로 모았습니다 (#73).
 
 - `HwpParaText.wcharCount`가 문단당 reduce 재계산에서 **파스 루프 누적 저장값**
   으로 바뀌었습니다 (#67). 값·공개 API는 동일하고(`charArray` 변경 시 didSet

--- a/Sources/HwpKitCore/AGENTS.md
+++ b/Sources/HwpKitCore/AGENTS.md
@@ -68,6 +68,15 @@ CoreHwp.HwpFile
 공유 흐름 상태 (`contentHeightUsed`·`paragraphAnchorTop`)와 `currentBlocks`
 재작성 적용은 paginator에 남는다.
 
+**개체 앵커 산식은 `Layout/HwpObjectAnchorGeometry.swift`가 단일 소유한다** (#73).
+페이지 흐름 경로(`HwpPaginator`)와 컨테이너 안 수집 경로
+(`HwpParagraphObjectCollector`)가 같은 식을 각자 구현하고 "같은 산식"이라는
+주석으로만 묶여 있던 것을 합쳤다 — 정렬 반영 좌표(`aligned`)와 글자처럼 취급
+개체의 줄 앵커 좌표(`inlineAnchorOrigin`) 둘이다. 한쪽만 고치면 조용히 갈라지던
+자리이므로 **새 개체 배치 산식도 두 경로가 공유하면 여기 둔다.**
+반면 컨테이너 경로의 `origin(commonProperty:size:placement:cursorX:)`은 페이지
+경로 `anchoredObjectFrame`의 **문단 rect 근사**라 같은 함수가 아니다 — 합치지 말 것.
+
 **부분 복구 placeholder 진단** (#65): `recoverPartialContent`가 남긴 손상
 문단·구역 placeholder를 `unsupportedElements()`에 `kind: .placeholder`로 내보내
 복구가 내용을 조용히 숨기지 않게 한다 (렌더는 placeholder의 빈 텍스트를 그리지
@@ -179,7 +188,7 @@ CT 측정보다 우선한다 — 폰트 대체로 줄 수가 부풀어 배치가
 - `HwpPaintCommand` = `@unchecked Sendable` enum. CF/NS 참조 타입을 담기 때문에 자동 Sendable 불가. enum case는 가로챌 init이 없어 **소유권 경계에서 동결**한다 — `HwpLaidOutParagraph.init`이 `NSAttributedString`을, `HwpShapeGeometry.init`이 `CGPath`를 복사본으로 저장한다 (mutable 서브클래스를 그대로 retain하면 Hashable 불변성·actor 경계 안전성이 깨진다). 새 참조 타입 payload를 추가하면 그 생산 지점에서 같은 복사를 해야 한다. 소유권 경계를 거치지 않고 **painter가 `.drawText`를 직접 만드는 경로도 마찬가지** — `HwpMemoPanelPainter`는 헤더를 `NSMutableAttributedString`으로 조립한 뒤 `NSAttributedString(attributedString:)`로 동결해 싣는다. 이제 actor 안전성 말고 **소비자**도 생겼다: HwpKitNative의 줄 배치 캐시가 문자열 신원 (`===`)으로 조판 결과를 재사용하므로 "신원이 같으면 내용도 같다"가 전 생산 경로에서 성립해야 한다 (깨지면 조용한 오조판)
 - 케이스: `fillRect` / `strokeRect` / `drawText` / `drawPath` / `drawImage` / `drawImageReference(binItemId:rect:)` / `drawPlaceholder` / `hyperlink`
 - `drawImageReference` 는 비트맵을 운반하지 않는다 — HwpKitNative 의 `HwpPageImageProvider` 가 `HwpImageStore` + `HwpImageCache` + `HwpImageAdapter` 로 지연 디코딩
-- **`HwpPage.==` / `hash` 는 `paintList.commands.count` 만 비교** (structural fingerprint). 렌더 결과 비교용으로 쓰지 말 것
+- **`HwpPage.==` / `hash` 에 `paintList` 는 들어가지 않는다** (#72) — size·margins·blocks·pageNumber 와 메모 패널 기하 (width·contentHeight) 로만 판정한다. 본문 paint 커맨드는 blocks 의 파생값이고, CF payload 는 Equatable 이 아니라 개수 말고는 비교할 수단도 없었다. 렌더 결과 비교용으로 쓰지 말 것 — 여기서 같다는 것은 조판 구조가 같다는 뜻이다. 이 동등성은 렌더 갱신뿐 아니라 **선택 지오메트리 재생성과 검색 재스캔 생략** (`HwpSelectionController` → `HwpSearchController.isEquivalentRefresh`) 의 입력이기도 하다
 - **메모 (댓글) 풍선**: `HwpPage.memoPanel` (`HwpMemoPanel` — 폭 + 패널 로컬
   paintList)에 분리 저장 — 종이 밖 오른쪽 패널이라 페이지 paintList/PrvImage
   정합에 영향 없음. 내용은 CoreHwp `HwpParagraph.memoParagraphArray` (MEMO_LIST
@@ -371,8 +380,7 @@ CT 측정보다 우선한다 — 폰트 대체로 줄 수가 부풀어 배치가
   단언할 것
 - 실측 튜닝 상수는 `Tuning/HwpRenderTuning.swift` 에 근거 주석과 함께 —
   값 변경은 fidelity 전수 + 블록 스냅샷 + 실물 대조 필수 (값 핀:
-  `HwpRenderTuningTests`). 차트 투영 기하 (`HwpChartPainter`)와 각주 예약
-  근사 (`HwpPaginator`)는 예외로 in-place
+  `HwpRenderTuningTests`). 차트 투영 기하 (`HwpChartPainter`)는 예외로 in-place
 - borderFill 참조는 **1-based (0 = 없음)**: `resolvedBorderFill` 은 id-1 을 먼저, 원래 id 를 다음에 시도
 - Sendable actor: `HwpPaginator`, `HwpImageCache` (HwpKitNative)
 - **`HwpFontResolver.testDeterministic`은 폰트 조회 세 축을 모두 닫는다** —
@@ -525,7 +533,7 @@ paraShape와 같은 값**이어야 한다.
 
 ## 안티 패턴 / 남은 한계
 
-- `HwpPage` 렌더 결과가 다른지 `==` 로 확인 — 안 됨 (count 만 비교). blocks 배열이나 paintList.commands 를 직접 순회할 것
+- `HwpPage` 렌더 결과가 다른지 `==` 로 확인 — 안 됨 (`paintList` 가 아예 항에 없다). blocks 배열이나 paintList.commands 를 직접 순회할 것
 - 수식 (`eqed`) 은 EQEDIT 스크립트를 한 줄 텍스트로 근사 (`HwpEquationLayout`
   — 기호 토큰 치환 + 관계 연산자 공백, 라틴 문자 이탤릭). 분수/근호 같은
   구조 조판은 없음 — 스크립트 원문이 노출된다
@@ -821,8 +829,9 @@ paraShape와 같은 값**이어야 한다.
   그 배치 방식은 겹치는 것이 설계라(위 "앵커 규칙") 담으려고 컨테이너를 키우면
   셀 안 워터마크·말풍선 하나가 행을 부풀린다. 술어는
   `HwpParagraphObjectCollector.consumesFlow`가 **단일 소유**하고 페이지 흐름
-  경로(`HwpPaginator.consumesFlow`)가 그것을 부른다 — 갈리면 흐름에서 자리를
-  안 주는 개체가 컨테이너만 키우는 모순이 된다. 여기서 빠져도 셀 콘텐츠로
+  경로(`HwpPaginator`)가 그 static 메서드를 직접 부른다 (#73 — 종전의 동명
+  위임 래퍼는 제거했다) — 갈리면 흐름에서 자리를 안 주는 개체가 컨테이너만
+  키우는 모순이 된다. 여기서 빠져도 셀 콘텐츠로
   그려지는 것은 그대로다 (`paintsBehindText`) — 빠지는 것은 **높이 하한뿐**이고,
   수집에서 빼면 개체 소실 회귀다.
   `objects()`의 기록 조건과 `hasFloatingObject` 사전 판정도 **반드시 같은

--- a/Sources/HwpKitCore/AGENTS.md
+++ b/Sources/HwpKitCore/AGENTS.md
@@ -68,6 +68,23 @@ CoreHwp.HwpFile
 공유 흐름 상태 (`contentHeightUsed`·`paragraphAnchorTop`)와 `currentBlocks`
 재작성 적용은 paginator에 남는다.
 
+**문단 루프는 넷으로 갈린다** (#73): `computeNextPage`는 `nextParagraph()` 순회와
+`ParagraphOutcome`(`.advance` / `.yieldToCaller`) 분기만 들고, 문단 하나의 처리는
+`processParagraph`, 측정 메모 재사용은 `measuredParagraph`, 문서 끝 밴드 닫기와
+각주·미주 드레인은 `finishPagination`이 맡는다. 동작은 종전과 같다.
+
+**양보와 취소 관찰은 별개 축이다** (#73). `Task.yield()`는 문단마다가 아니라
+`yieldBatchSize`(16) 문단마다 한 번이다 — 문단 단위 양보 두 자리(문단 배치 뒤·
+측정 진입)가 `yieldPeriodically`를 지난다 (`computeNextPage` 진입의 양보는 호출당
+한 번이라 배칭 대상이 아니다). 20,000문단이면 최대 40,000회이던 스케줄러 왕복이
+2,500회가 된다. **취소 응답은 이 배칭에 영향받지 않는다** — `processParagraph`가
+문단마다 `Task.checkCancellation()`을 그대로 부르고, 각주·미주 드레인 루프는
+페이지마다 부른다. 배칭이 늦추는 것은 다른 Task에게 실행을 넘기는 시점뿐이다.
+취소 검사를 배칭에 합치거나 배치 크기를 키우면 그만큼 취소 응답이 늦어진다.
+가드는 `HwpPaginatorCancellationTests` — paginator 자체의 취소 관찰을 재는 저장소
+최초의 스위트다 (종전에는 HwpKitNative의 액터 스모크뿐이라, 배칭이 취소를 문서
+끝까지 밀어 버려도 아무것도 빨개지지 않았다).
+
 **개체 앵커 산식은 `Layout/HwpObjectAnchorGeometry.swift`가 단일 소유한다** (#73).
 페이지 흐름 경로(`HwpPaginator`)와 컨테이너 안 수집 경로
 (`HwpParagraphObjectCollector`)가 같은 식을 각자 구현하고 "같은 산식"이라는
@@ -76,6 +93,9 @@ CoreHwp.HwpFile
 자리이므로 **새 개체 배치 산식도 두 경로가 공유하면 여기 둔다.**
 반면 컨테이너 경로의 `origin(commonProperty:size:placement:cursorX:)`은 페이지
 경로 `anchoredObjectFrame`의 **문단 rect 근사**라 같은 함수가 아니다 — 합치지 말 것.
+가드는 `HwpObjectAnchorGeometryTests`의 정렬 분기 전수다. 픽스처가 닿는 분기는
+`topOrLeft`/nil뿐이라 나머지는 어느 게이트도 잡지 못했다 — `.center`를 1pt 틀어도
+블록 스냅샷과 렌더 해시가 모두 초록이었다. 합치는 김에 그 구멍을 닫았다.
 
 **부분 복구 placeholder 진단** (#65): `recoverPartialContent`가 남긴 손상
 문단·구역 placeholder를 `unsupportedElements()`에 `kind: .placeholder`로 내보내
@@ -188,7 +208,7 @@ CT 측정보다 우선한다 — 폰트 대체로 줄 수가 부풀어 배치가
 - `HwpPaintCommand` = `@unchecked Sendable` enum. CF/NS 참조 타입을 담기 때문에 자동 Sendable 불가. enum case는 가로챌 init이 없어 **소유권 경계에서 동결**한다 — `HwpLaidOutParagraph.init`이 `NSAttributedString`을, `HwpShapeGeometry.init`이 `CGPath`를 복사본으로 저장한다 (mutable 서브클래스를 그대로 retain하면 Hashable 불변성·actor 경계 안전성이 깨진다). 새 참조 타입 payload를 추가하면 그 생산 지점에서 같은 복사를 해야 한다. 소유권 경계를 거치지 않고 **painter가 `.drawText`를 직접 만드는 경로도 마찬가지** — `HwpMemoPanelPainter`는 헤더를 `NSMutableAttributedString`으로 조립한 뒤 `NSAttributedString(attributedString:)`로 동결해 싣는다. 이제 actor 안전성 말고 **소비자**도 생겼다: HwpKitNative의 줄 배치 캐시가 문자열 신원 (`===`)으로 조판 결과를 재사용하므로 "신원이 같으면 내용도 같다"가 전 생산 경로에서 성립해야 한다 (깨지면 조용한 오조판)
 - 케이스: `fillRect` / `strokeRect` / `drawText` / `drawPath` / `drawImage` / `drawImageReference(binItemId:rect:)` / `drawPlaceholder` / `hyperlink`
 - `drawImageReference` 는 비트맵을 운반하지 않는다 — HwpKitNative 의 `HwpPageImageProvider` 가 `HwpImageStore` + `HwpImageCache` + `HwpImageAdapter` 로 지연 디코딩
-- **`HwpPage.==` / `hash` 에 `paintList` 는 들어가지 않는다** (#72) — size·margins·blocks·pageNumber 와 메모 패널 기하 (width·contentHeight) 로만 판정한다. 본문 paint 커맨드는 blocks 의 파생값이고, CF payload 는 Equatable 이 아니라 개수 말고는 비교할 수단도 없었다. 렌더 결과 비교용으로 쓰지 말 것 — 여기서 같다는 것은 조판 구조가 같다는 뜻이다. 이 동등성은 렌더 갱신뿐 아니라 **선택 지오메트리 재생성과 검색 재스캔 생략** (`HwpSelectionController` → `HwpSearchController.isEquivalentRefresh`) 의 입력이기도 하다
+- **`HwpPage.==` / `hash` 에 `paintList` 는 들어가지 않는다** (#72) — size·margins·blocks·pageNumber 와 메모 패널 기하 (width·contentHeight) 로만 판정한다. 본문 paint 커맨드는 blocks 의 파생값이고, CF payload 는 Equatable 이 아니라 개수 말고는 비교할 수단도 없었다. 렌더 결과 비교용으로 쓰지 말 것 — 여기서 같다는 것은 조판 구조가 같다는 뜻이다. 이 동등성은 렌더 갱신뿐 아니라 **선택 지오메트리 재생성과 검색 재스캔 생략** (`HwpSelectionController` → `HwpSearchController.isEquivalentRefresh`) 의 입력이기도 하다. 가드는 `HwpPageEqualityContractTests` — paint 항이 빠졌다는 것뿐 아니라 **남은 항이 여전히 판별한다**는 것 (blocks·pageNumber·메모 패널 기하) 과 위 두 소비자에 닿는 것까지 함께 잠근다. 종전 `paintList.commands.count` 항을 잠그는 테스트는 저장소 전체에 0건이라 그 항은 빼도 넣어도 아무것도 빨개지지 않았다
 - **메모 (댓글) 풍선**: `HwpPage.memoPanel` (`HwpMemoPanel` — 폭 + 패널 로컬
   paintList)에 분리 저장 — 종이 밖 오른쪽 패널이라 페이지 paintList/PrvImage
   정합에 영향 없음. 내용은 CoreHwp `HwpParagraph.memoParagraphArray` (MEMO_LIST
@@ -381,6 +401,13 @@ CT 측정보다 우선한다 — 폰트 대체로 줄 수가 부풀어 배치가
 - 실측 튜닝 상수는 `Tuning/HwpRenderTuning.swift` 에 근거 주석과 함께 —
   값 변경은 fidelity 전수 + 블록 스냅샷 + 실물 대조 필수 (값 핀:
   `HwpRenderTuningTests`). 차트 투영 기하 (`HwpChartPainter`)는 예외로 in-place
+- **UI 색 리터럴은 실측 튜닝 상수가 아니다** — `Utils/HwpColor+CGColor.swift` 의
+  `CGColor` 확장에 둔다 (`hwpBlack`·`hwpWhite`·`hwpTrackChange`). 한글 실물과
+  맞춘 수치가 아니라 우리가 고른 색이라 fidelity 게이트의 대상이 아니고, 그래서
+  `HwpRenderTuning` 에 넣으면 값 핀·실물 대조 절차가 헛돈다. 변경 추적 표시색은
+  `HwpTextRunBuilderMarks` (삽입·삭제 글자) 와 `HwpPaginator.emitTrackChangeBars`
+  (문단 왼쪽 변경 막대) 두 곳에 각각 하드코딩돼 있던 것을 #73이 `hwpTrackChange`
+  하나로 합쳤다 — 갈리면 같은 변경의 글자와 막대가 다른 빨강으로 그려진다
 - borderFill 참조는 **1-based (0 = 없음)**: `resolvedBorderFill` 은 id-1 을 먼저, 원래 id 를 다음에 시도
 - Sendable actor: `HwpPaginator`, `HwpImageCache` (HwpKitNative)
 - **`HwpFontResolver.testDeterministic`은 폰트 조회 세 축을 모두 닫는다** —
@@ -915,8 +942,9 @@ paraShape와 같은 값**이어야 한다.
   (표시용 본문)에 있다 — `HwpFile.displaySectionArray`가 ViewText 우선으로
   렌더 본문을 고른다 (한글.app 동작). 표식은 PARA_RANGE_TAG (kind 16 삽입 /
   17 삭제)로 오고 `HwpTextRunBuilder`가 빨강 밑줄/취소선으로, 문단 왼쪽 변경
-  막대는 `appendTrackChangeBarIfNeeded`가 그린다. 작성자별 색 구분은 없음
-  (항상 빨강)
+  막대는 `emitTrackChangeBars`가 페이지 캐시 직전에 조각마다 그린다. 두 경로가
+  쓰는 빨강은 `CGColor.hwpTrackChange` 하나다 (위 "컨벤션"). 작성자별 색 구분은
+  없음 (항상 빨강)
 - 머리말/꼬리말 밴드 텍스트가 밴드 높이를 넘으면 본문과 겹칠 수 있다 (클립 없음)
 - 각주의 표 134 bits 8-9 (한 페이지 안 다단 배열 방식) 미적용 — 항상 전체 폭 하단
 - 표 셀/글상자 안 본문 문단의 각주 참조 (ext17) 위 첨자 번호는 미표시

--- a/Sources/HwpKitCore/Layout/HwpObjectAnchorGeometry.swift
+++ b/Sources/HwpKitCore/Layout/HwpObjectAnchorGeometry.swift
@@ -1,0 +1,52 @@
+import CoreGraphics
+import CoreHwp
+import Foundation
+
+/// 개체 앵커 좌표 산식의 **단일 소유자** (#73).
+///
+/// 같은 산식을 두 경로가 쓴다 — 페이지 흐름 경로(`HwpPaginator`)와 컨테이너 안
+/// 수집 경로(`HwpParagraphObjectCollector`). 종전에는 두 곳이 각자 구현을 들고
+/// "같은 산식이다"라고 주석으로만 묶여 있어, 한쪽만 고치면 조용히 갈라졌다.
+/// #80이 측정·렌더 줄바꿈에 대해 `HwpLineBreaker`로 한 것과 같은 처리다.
+///
+/// **여기 들어오는 것은 두 경로가 실제로 공유하는 산식뿐이다.** 컨테이너 경로의
+/// `origin(commonProperty:size:placement:cursorX:)`은 페이지 경로의
+/// `anchoredObjectFrame`을 문단 rect로 **근사**한 것이라 같은 함수가 아니다 —
+/// 옮기지 말 것. 공유하는 것은 그 근사가 안에서 부르는 `aligned`뿐이다.
+enum HwpObjectAnchorGeometry {
+    /// 앵커 규칙(표 70)의 기준 좌표(base) + 여유 폭(extent) + 개체 치수(size)와
+    /// 정렬로 배치 좌표를 낸다.
+    ///
+    /// `extent`가 0이면 정렬이 무효다 — 페이지 경로에서 세로 기준이 '문단'일 때
+    /// extent를 0으로 넘겨 정렬을 끄는 것이 이 규칙에 기댄다.
+    static func aligned(
+        base: CGFloat,
+        extent: CGFloat,
+        size: CGFloat,
+        alignment: CoreHwp.HwpCommonCtrlRelativeAlignment?
+    ) -> CGFloat {
+        guard extent > 0 else { return base }
+        return switch alignment {
+        case .center: base + (extent - size) / 2
+        case .bottomOrRight, .outside: base + extent - size
+        case .topOrLeft, .inside, nil: base
+        }
+    }
+
+    /// 글자처럼 취급되는 개체의 줄 앵커 좌표 — 문단 rect 원점 기준.
+    ///
+    /// 세로는 **baseline − ascent = 개체 상단**이고, baseline은 문단 첫 줄의
+    /// baseline에 그 줄의 origin.y를 더한 값이다. 두 경로가 이 식을 공유한다.
+    static func inlineAnchorOrigin(
+        paragraphOrigin: CGPoint,
+        firstBaseline: CGFloat,
+        lineOrigin: CGPoint,
+        xOffset: CGFloat,
+        ascent: CGFloat
+    ) -> CGPoint {
+        CGPoint(
+            x: paragraphOrigin.x + lineOrigin.x + xOffset,
+            y: paragraphOrigin.y + firstBaseline + lineOrigin.y - ascent
+        )
+    }
+}

--- a/Sources/HwpKitCore/Layout/HwpPaginator.swift
+++ b/Sources/HwpKitCore/Layout/HwpPaginator.swift
@@ -120,6 +120,17 @@ public actor HwpPaginator {
     }
 
     private var measureMemo: ParagraphMeasureMemo?
+    /// 문단 단위 `Task.yield()` 배칭 카운터 (#73 조각 3).
+    ///
+    /// 문단마다 최대 두 번(배치 뒤·측정 진입) 양보하던 것을 `yieldBatchSize`
+    /// 문단마다 한 번으로 줄인다 — 20,000 문단이면 최대 40,000회가 2,500회가 된다.
+    /// 취소 **관찰**은 이 배칭과 독립이다: `processParagraph`가 문단마다
+    /// `Task.checkCancellation()`을 그대로 부른다. 배칭이 늦추는 것은 다른
+    /// Task에게 실행을 넘기는 시점뿐이다.
+    private var yieldCounter = 0
+    /// 양보 주기 (문단 수). 16은 취소 응답 지연(문단 16개 처리 시간)과
+    /// 스케줄러 왕복 절감의 절충이다.
+    static let yieldBatchSize = 16
     /// 이번 배치가 각주를 **조각 단위로 이미 수집했는지** (#95). 페이지에 걸친
     /// 절대 캐시 문단은 run마다 그 조각의 각주를 그 페이지에 담으므로, 문단 루프의
     /// 문단 단위 수집을 건너뛰어야 이중 수집(번호 중복)이 되지 않는다.
@@ -524,6 +535,16 @@ private extension HwpPaginator {
         bandUsedBottom = plan.maxBottom
     }
 
+    /// `processParagraph` 한 번의 결과 — 문단 루프를 계속할지, `computeNextPage`가
+    /// 호출자에게 돌아갈지를 가른다.
+    enum ParagraphOutcome {
+        /// 다음 문단으로 진행한다.
+        case advance
+        /// 이 호출을 여기서 끝낸다 — 페이지 상한 도달, 쪽 나누기로 페이지 확정,
+        /// 배치 실패(문단을 다음 페이지에서 재처리), 또는 새 페이지 생성.
+        case yieldToCaller
+    }
+
     func computeNextPage() async throws {
         await Task.yield()
 
@@ -536,90 +557,118 @@ private extension HwpPaginator {
         let pageCountBefore = cachedPages.count
 
         while let paragraph = nextParagraph() {
-            // 페이지 상한 도달 후 남은 문단은 레이아웃해도 캐시되지 않는다 —
-            // 즉시 종료해 상한이 CPU 상한으로도 작동하게 한다 (#1).
-            if didFinishPagination {
-                return
-            }
-            // 취소된 로드가 0-높이 문단을 대량 처리할 때 page(at:) 반환 전에
-            // 취소를 관찰해 옛 문서 레이아웃이 교체본과 나란히 도는 것을 막는다 (#3).
-            try Task.checkCancellation()
-            // 구역 시작/쪽 나누기 문단: 진행 중인 페이지를 확정하고 이 문단은
-            // 다음 호출에서 새 페이지 첫머리로 다시 처리한다.
-            if try flushPageBeforeProcessing(paragraph) {
-                return
-            }
-
-            applySectionDef(in: paragraph)
-            applyColumnDef(in: paragraph)
-            applyNewNumbers(in: paragraph)
-            currentParagraphMargins = paragraphMargins(of: paragraph)
-
-            let widthCenti = Int((currentColumnFrame.width * 100).rounded())
-            let replacements = noteReferenceReplacements(for: paragraph)
-            let attributedString: NSAttributedString
-            let paragraphFrame: HwpParagraphFrame
-            if let memo = measureMemo,
-               memo.sectionIndex == nextSectionIndex,
-               memo.paragraphIndex == nextParagraphIndex,
-               memo.widthCenti == widthCenti,
-               memo.replacements == replacements
-            {
-                attributedString = memo.attributedString
-                paragraphFrame = memo.paragraphFrame
-            } else {
-                attributedString = textRunBuilder()
-                    .build(paragraph: paragraph, controlReplacements: replacements)
-                paragraphFrame = if absoluteCachePlacer.canSkipMeasurement(
-                    for: paragraph,
-                    attributedString: attributedString,
-                    columnCount: columnFrames.count
-                ) {
-                    HwpParagraphFrame(totalHeight: 0, lines: [])
-                } else {
-                    try await layout(paragraph, attributedString: attributedString)
-                }
-            }
-            // 번호/개요 문단 머리의 진단 페이지는 문단이 시작하는 첫 페이지다 —
-            // placeParagraphText가 다중 페이지 문단의 앞 조각 페이지를 먼저
-            // 캐시하므로 배치 전에 첫 페이지를 잡는다 (#3).
-            let paragraphFirstPage = cachedPages.count + 1
-            currentParagraphFirstPlacedPage = nil
-            guard placeParagraphText(
-                paragraph,
-                attributedString: attributedString,
-                paragraphFrame: paragraphFrame
-            ) else {
-                // 현재 페이지가 확정됐고 문단은 다음 페이지에서 다시 처리한다 —
-                // 빌드 입력이 그대로면 메모로 build + CT 재실행을 건너뛴다.
-                measureMemo = ParagraphMeasureMemo(
-                    sectionIndex: nextSectionIndex,
-                    paragraphIndex: nextParagraphIndex,
-                    widthCenti: widthCenti,
-                    replacements: replacements,
-                    attributedString: attributedString,
-                    paragraphFrame: paragraphFrame
-                )
-                return
-            }
-            measureMemo = nil
-            collectParagraphFootnotesUnlessPlacedPerFragment(paragraph)
-            collectMemos(from: paragraph)
-            appendControlBlocks(from: paragraph)
-            collectUnsupported(from: paragraph, firstPage: paragraphFirstPage)
-            collectOutline(from: paragraph, firstPage: paragraphFirstPage)
-            advanceParagraph()
-            await Task.yield()
-
-            // 이 호출에서 이미 페이지가 생겼으면 반환해 호출자가 진행을 관찰하게 한다.
-            if cachedPages.count > pageCountBefore {
+            let outcome = try await processParagraph(paragraph, pageCountBefore: pageCountBefore)
+            if outcome == .yieldToCaller {
                 return
             }
         }
 
-        // 문서 끝: 밴드를 닫고 마지막 본문 페이지를 확정한 뒤, 남은 미주는
-        // 새 쪽에서 시작한다 (한글.app 실측 2026-07-06 — footnote-endnote
-        // 픽스처의 미주가 2쪽에 표시됨을 사용자 확인).
+        try finishPagination()
+    }
+
+    /// 문단 하나를 처리한다 — 페이지 확정 판정, 구역·단 정의 적용, 측정, 배치,
+    /// 부수 수집(각주·메모·컨트롤·미지원·개요)까지.
+    ///
+    /// `pageCountBefore`는 이 `computeNextPage` 호출 진입 시점의 캐시 페이지 수다 —
+    /// 이 호출에서 페이지가 하나라도 생기면 호출자가 진행을 관찰하도록 돌아간다.
+    func processParagraph(
+        _ paragraph: CoreHwp.HwpParagraph,
+        pageCountBefore: Int
+    ) async throws -> ParagraphOutcome {
+        // 페이지 상한 도달 후 남은 문단은 레이아웃해도 캐시되지 않는다 —
+        // 즉시 종료해 상한이 CPU 상한으로도 작동하게 한다 (#1).
+        if didFinishPagination {
+            return .yieldToCaller
+        }
+        // 취소된 로드가 0-높이 문단을 대량 처리할 때 page(at:) 반환 전에
+        // 취소를 관찰해 옛 문서 레이아웃이 교체본과 나란히 도는 것을 막는다 (#3).
+        try Task.checkCancellation()
+        // 구역 시작/쪽 나누기 문단: 진행 중인 페이지를 확정하고 이 문단은
+        // 다음 호출에서 새 페이지 첫머리로 다시 처리한다.
+        if try flushPageBeforeProcessing(paragraph) {
+            return .yieldToCaller
+        }
+
+        applySectionDef(in: paragraph)
+        applyColumnDef(in: paragraph)
+        applyNewNumbers(in: paragraph)
+        currentParagraphMargins = paragraphMargins(of: paragraph)
+
+        let widthCenti = Int((currentColumnFrame.width * 100).rounded())
+        let replacements = noteReferenceReplacements(for: paragraph)
+        let measured = try await measuredParagraph(
+            paragraph,
+            widthCenti: widthCenti,
+            replacements: replacements
+        )
+        // 번호/개요 문단 머리의 진단 페이지는 문단이 시작하는 첫 페이지다 —
+        // placeParagraphText가 다중 페이지 문단의 앞 조각 페이지를 먼저
+        // 캐시하므로 배치 전에 첫 페이지를 잡는다 (#3).
+        let paragraphFirstPage = cachedPages.count + 1
+        currentParagraphFirstPlacedPage = nil
+        guard placeParagraphText(
+            paragraph,
+            attributedString: measured.attributedString,
+            paragraphFrame: measured.paragraphFrame
+        ) else {
+            // 현재 페이지가 확정됐고 문단은 다음 페이지에서 다시 처리한다 —
+            // 빌드 입력이 그대로면 메모로 build + CT 재실행을 건너뛴다.
+            measureMemo = ParagraphMeasureMemo(
+                sectionIndex: nextSectionIndex,
+                paragraphIndex: nextParagraphIndex,
+                widthCenti: widthCenti,
+                replacements: replacements,
+                attributedString: measured.attributedString,
+                paragraphFrame: measured.paragraphFrame
+            )
+            return .yieldToCaller
+        }
+        measureMemo = nil
+        collectParagraphFootnotesUnlessPlacedPerFragment(paragraph)
+        collectMemos(from: paragraph)
+        appendControlBlocks(from: paragraph)
+        collectUnsupported(from: paragraph, firstPage: paragraphFirstPage)
+        collectOutline(from: paragraph, firstPage: paragraphFirstPage)
+        advanceParagraph()
+        await yieldPeriodically()
+
+        // 이 호출에서 이미 페이지가 생겼으면 반환해 호출자가 진행을 관찰하게 한다.
+        return cachedPages.count > pageCountBefore ? .yieldToCaller : .advance
+    }
+
+    /// 문단의 텍스트 런과 조판 프레임을 만든다 — 직전 호출이 배치에 실패해 남긴
+    /// 측정 메모가 같은 입력이면 재사용해 build + CoreText 재실행을 건너뛴다.
+    func measuredParagraph(
+        _ paragraph: CoreHwp.HwpParagraph,
+        widthCenti: Int,
+        replacements: [Int: HwpControlMarkerReplacement]
+    ) async throws -> (attributedString: NSAttributedString, paragraphFrame: HwpParagraphFrame) {
+        if let memo = measureMemo,
+           memo.sectionIndex == nextSectionIndex,
+           memo.paragraphIndex == nextParagraphIndex,
+           memo.widthCenti == widthCenti,
+           memo.replacements == replacements
+        {
+            return (memo.attributedString, memo.paragraphFrame)
+        }
+        let attributedString = textRunBuilder()
+            .build(paragraph: paragraph, controlReplacements: replacements)
+        let paragraphFrame: HwpParagraphFrame = if absoluteCachePlacer.canSkipMeasurement(
+            for: paragraph,
+            attributedString: attributedString,
+            columnCount: columnFrames.count
+        ) {
+            HwpParagraphFrame(totalHeight: 0, lines: [])
+        } else {
+            try await layout(paragraph, attributedString: attributedString)
+        }
+        return (attributedString, paragraphFrame)
+    }
+
+    /// 문서 끝 처리 — 밴드를 닫고 마지막 본문 페이지를 확정한 뒤, 남은 미주는
+    /// 새 쪽에서 시작한다 (한글.app 실측 2026-07-06 — footnote-endnote
+    /// 픽스처의 미주가 2쪽에 표시됨을 사용자 확인).
+    func finishPagination() throws {
         closeColumnBand()
         if !pendingEndnotes.isEmpty, !currentBlocks.isEmpty || contentHeightUsed > 0 {
             cacheCurrentPage()
@@ -631,11 +680,25 @@ private extension HwpPaginator {
         // = true, pendingFootnotes 불변) 무한 회전하므로 그때 멈춘다 (#4).
         while !pendingFootnotes.isEmpty, !didFinishPagination {
             // 취소 시 각주 드레인이 페이지 상한까지 동기로 돌아 취소 관찰이
-            // 늦어지지 않게 매 페이지 확인 (문단 루프 389와 동일, P2b).
+            // 늦어지지 않게 매 페이지 확인 (`processParagraph`의 문단 루프와
+            // 같은 이유, P2b).
             try Task.checkCancellation()
             cacheCurrentPage()
         }
         didFinishPagination = true
+    }
+
+    /// `yieldBatchSize` 문단마다 한 번만 양보한다.
+    ///
+    /// 문단마다 양보하면 20,000 문단 문서에서 최대 40,000번의 스케줄러 왕복이
+    /// 생기는데, 그 대부분은 다른 Task가 없어 즉시 되돌아온다. 취소 관찰은
+    /// `Task.checkCancellation()`이 문단마다 따로 하므로 이 배칭에 영향받지 않는다.
+    func yieldPeriodically() async {
+        yieldCounter += 1
+        if yieldCounter >= Self.yieldBatchSize {
+            yieldCounter = 0
+            await Task.yield()
+        }
     }
 
     /// 새 구역 정의 (이전 구역의 밴드를 닫고 구역-끝 미주 배치) 또는
@@ -717,7 +780,7 @@ private extension HwpPaginator {
     private func emitTrackChangeBars() {
         guard !trackChangeParagraphIds.isEmpty else { return }
         let barX = currentPageGeometry.contentFrame.minX - 10
-        let barColor = CGColor(srgbRed: 0.87, green: 0.14, blue: 0.1, alpha: 1)
+        let barColor = CGColor.hwpTrackChange
         let bars: [AnyHwpBlock] = currentBlocks.compactMap { block in
             guard block.kind == .text,
                   let paragraphId = block.source?.paragraphId,
@@ -1153,7 +1216,7 @@ private extension HwpPaginator {
         _ paragraph: CoreHwp.HwpParagraph,
         attributedString: NSAttributedString
     ) async throws -> HwpParagraphFrame {
-        await Task.yield()
+        await yieldPeriodically()
         return HwpParagraphLayout().layout(
             attributedString: attributedString,
             paraShape: index.paraShapeOrDefault(for: paragraph),
@@ -1902,7 +1965,8 @@ private extension HwpPaginator {
             availableWidth: currentColumnFrame.width,
             index: index,
             sizeResolver: objectSizeResolver,
-            clampToAvailableWidth: info.treatAsChar || consumesFlow(info)
+            clampToAvailableWidth: info.treatAsChar
+                || HwpParagraphObjectCollector.consumesFlow(info)
         )
         switch result {
         case let .failure(element):
@@ -1969,7 +2033,8 @@ private extension HwpPaginator {
         table: CoreHwp.HwpTable
     ) -> Bool {
         let info = table.commonCtrlProperty.propertyInfo
-        guard !info.treatAsChar, !consumesFlow(info) else { return false }
+        guard !info.treatAsChar,
+              !HwpParagraphObjectCollector.consumesFlow(info) else { return false }
         let height = frame.rows.reduce(CGFloat(0)) { max($0, $1.rowFrame.maxY) }
         appendFloatingBlock(
             ObjectBlockSpec(
@@ -2462,7 +2527,7 @@ private extension HwpPaginator {
             return
         }
 
-        if info.treatAsChar || consumesFlow(info) {
+        if info.treatAsChar || HwpParagraphObjectCollector.consumesFlow(info) {
             // 세로 기준이 종이/쪽/문단인 개체는 흐름 커서가 아니라 기준+
             // 오프셋 위치에 놓이고, 본문 흐름은 개체 아래로 밀린다
             // (한글 실측: text-box 종이 46.2/35.6mm, chart 문단 상단 —
@@ -2516,20 +2581,6 @@ private extension HwpPaginator {
         bandHasNonTextContent = true
     }
 
-    /// 기준 프레임(base, extent) 안에서 정렬을 반영한 앵커. topOrLeft(기본)·
-    /// nil·extent<=0이면 base 그대로 (오프셋 배치 개체 렌더 불변, #5).
-    private func alignedAnchor(
-        _ base: CGFloat, _ extent: CGFloat, _ size: CGFloat,
-        _ alignment: CoreHwp.HwpCommonCtrlRelativeAlignment?
-    ) -> CGFloat {
-        guard extent > 0 else { return base }
-        return switch alignment {
-        case .center: base + (extent - size) / 2
-        case .bottomOrRight, .outside: base + extent - size
-        case .topOrLeft, .inside, nil: base
-        }
-    }
-
     /// 앵커 규칙(표 70)의 기준 프레임(base, extent) + 정렬 + 오프셋으로 개체
     /// 프레임을 만든다. floating·absolute-flow 경로가 공유한다 (#5 정렬 반영).
     private func anchoredObjectFrame(
@@ -2554,10 +2605,14 @@ private extension HwpPaginator {
         case .paragraph: (paragraphAnchorTop, 0)
         }
         return CGRect(
-            x: alignedAnchor(hRef.base, hRef.extent, spec.size.width, info.horizontalAlignment)
-                + offsetX,
-            y: alignedAnchor(vRef.base, vRef.extent, spec.size.height, info.verticalAlignment)
-                + offsetY,
+            x: HwpObjectAnchorGeometry.aligned(
+                base: hRef.base, extent: hRef.extent,
+                size: spec.size.width, alignment: info.horizontalAlignment
+            ) + offsetX,
+            y: HwpObjectAnchorGeometry.aligned(
+                base: vRef.base, extent: vRef.extent,
+                size: spec.size.height, alignment: info.verticalAlignment
+            ) + offsetY,
             width: spec.size.width,
             height: spec.size.height
         )
@@ -2579,8 +2634,9 @@ private extension HwpPaginator {
               frame.maxY > currentPageGeometry.contentFrame.maxY
         else { return frame }
         advanceColumn()
-        // 페이지 상한 도달: advanceColumn이 커서를 못 옮기면 같은 frame으로
-        // 재귀가 반복된다 — 현재 frame을 그대로 쓴다 (#1).
+        // 페이지 상한 도달: advanceColumn이 커서를 못 옮기면 anchoredObjectFrame이
+        // 같은 frame을 돌려주고 이 함수가 다시 불려 제자리를 돈다 — 현재 frame을
+        // 그대로 쓴다 (#1). 이 함수가 자기를 재귀 호출하지는 않는다.
         if didFinishPagination {
             return frame
         }
@@ -2707,22 +2763,18 @@ private extension HwpPaginator {
         }
         var map: [Int: CGPoint] = [:]
         for line in context.lines {
-            let baselineY = context.blockFrame.minY + firstBaseline + line.origin.y
             for anchor in line.inlineAnchors where map[anchor.controlIndex] == nil {
-                map[anchor.controlIndex] = CGPoint(
-                    x: context.blockFrame.minX + line.origin.x + anchor.xOffset,
-                    y: baselineY - anchor.ascent
+                map[anchor.controlIndex] = HwpObjectAnchorGeometry.inlineAnchorOrigin(
+                    paragraphOrigin: context.blockFrame.origin,
+                    firstBaseline: firstBaseline,
+                    lineOrigin: line.origin,
+                    xOffset: anchor.xOffset,
+                    ascent: anchor.ascent
                 )
             }
         }
         inlineAnchorCache = map
         return map
-    }
-
-    /// 술어 본체는 `HwpParagraphObjectCollector.consumesFlow`가 소유한다 —
-    /// 컨테이너 높이 하한 (`growsContainer`)과 반드시 같은 답을 써야 한다 (#91).
-    func consumesFlow(_ info: CoreHwp.HwpCommonCtrlPropertyInfo) -> Bool {
-        HwpParagraphObjectCollector.consumesFlow(info)
     }
 
     func combinedAttributedString(_ strings: [NSAttributedString]) -> NSAttributedString? {
@@ -2948,7 +3000,8 @@ private extension HwpPaginator {
         // (각주 드레인 루프와 동일, #1).
         while !pendingEndnotes.isEmpty, !didFinishPagination {
             // 취소 시 미주 드레인이 페이지 상한까지 동기로 돌아 취소 관찰이
-            // 늦어지지 않게 매 페이지 확인 (각주 드레인·389와 동일, P2b).
+            // 늦어지지 않게 매 페이지 확인 (`finishPagination`의 각주 드레인·
+            // `processParagraph`와 같은 이유, P2b).
             try Task.checkCancellation()
             let columnFrame = currentColumnFrame
             let available = CGRect(
@@ -3069,7 +3122,7 @@ private extension HwpPaginator {
             blocks: currentBlocks,
             pageNumber: pageIndex + 1
         )
-        let paintList = paintListBuilder.build(for: page, index: index)
+        let paintList = paintListBuilder.build(for: page)
         // 메모 풍선은 종이 밖 오른쪽 패널 (한글.app 편집 뷰) — 페이지
         // paintList와 분리해 인쇄 뷰·PrvImage 정합에는 영향을 주지 않는다.
         let memoPanel = pendingMemoBalloons.isEmpty

--- a/Sources/HwpKitCore/Layout/HwpParagraphObjectCollector.swift
+++ b/Sources/HwpKitCore/Layout/HwpParagraphObjectCollector.swift
@@ -332,11 +332,11 @@ struct HwpParagraphObjectCollector {
         case .paragraph: 0
         }
         return CGPoint(
-            x: aligned(
+            x: HwpObjectAnchorGeometry.aligned(
                 base: rect.minX, extent: rect.width, size: size.width,
                 alignment: commonProperty.propertyInfo.horizontalAlignment
             ) + offsetX,
-            y: aligned(
+            y: HwpObjectAnchorGeometry.aligned(
                 base: rect.minY, extent: verticalExtent, size: size.height,
                 alignment: commonProperty.propertyInfo.verticalAlignment
             ) + offsetY
@@ -357,9 +357,12 @@ struct HwpParagraphObjectCollector {
         for line in frame.lines {
             for anchor in line.inlineAnchors where anchor.controlIndex == controlIndex {
                 return LineAnchor(
-                    origin: CGPoint(
-                        x: paragraphRect.minX + line.origin.x + anchor.xOffset,
-                        y: paragraphRect.minY + firstBaseline + line.origin.y - anchor.ascent
+                    origin: HwpObjectAnchorGeometry.inlineAnchorOrigin(
+                        paragraphOrigin: paragraphRect.origin,
+                        firstBaseline: firstBaseline,
+                        lineOrigin: line.origin,
+                        xOffset: anchor.xOffset,
+                        ascent: anchor.ascent
                     ),
                     reserved: CGSize(width: anchor.width, height: anchor.ascent)
                 )
@@ -663,20 +666,5 @@ extension HwpParagraphObjectCollector {
     ) -> Bool {
         growsContainer(commonProperty)
             || (commonProperty?.propertyInfo.treatAsChar ?? true)
-    }
-}
-
-private extension HwpParagraphObjectCollector {
-    /// 정렬 반영 좌표 — HwpPaginator.alignedAnchor와 같은 산식.
-    func aligned(
-        base: CGFloat, extent: CGFloat, size: CGFloat,
-        alignment: CoreHwp.HwpCommonCtrlRelativeAlignment?
-    ) -> CGFloat {
-        guard extent > 0 else { return base }
-        return switch alignment {
-        case .center: base + (extent - size) / 2
-        case .bottomOrRight, .outside: base + extent - size
-        case .topOrLeft, .inside, nil: base
-        }
     }
 }

--- a/Sources/HwpKitCore/Layout/HwpTextRunBuilderMarks.swift
+++ b/Sources/HwpKitCore/Layout/HwpTextRunBuilderMarks.swift
@@ -12,7 +12,7 @@ extension HwpTextRunBuilder {
         to attributes: inout [NSAttributedString.Key: Any]
     ) {
         guard mark == 16 || mark == 17 else { return }
-        let red = CGColor(srgbRed: 0.87, green: 0.14, blue: 0.1, alpha: 1)
+        let red = CGColor.hwpTrackChange
         attributes[kCTForegroundColorAttributeName as NSAttributedString.Key] = red
         if mark == 17 {
             attributes[HwpAttributedStringKey.strikethroughStyle] = NSNumber(value: 1)

--- a/Sources/HwpKitCore/Layout/Paginator/HwpOutlineCollector.swift
+++ b/Sources/HwpKitCore/Layout/Paginator/HwpOutlineCollector.swift
@@ -11,7 +11,7 @@ import Foundation
 /// `0x80000000` 한 값이 12,580회 나온다. `noori`는 문단 65개에 distinct
 /// `paraId`가 2개다).
 ///
-/// 본체(2,800줄)가 아니라 별도 파일에 두는 것은 관례이자 필수다 — swiftlint
+/// 본체(`HwpPaginator`)가 아니라 별도 파일에 두는 것은 관례이자 필수다 — swiftlint
 /// `file_length` error가 700이라 기존 `Paginator/` 파일에 얹으면 Lint가
 /// 떨어진다.
 ///

--- a/Sources/HwpKitCore/Model/HwpPage.swift
+++ b/Sources/HwpKitCore/Model/HwpPage.swift
@@ -56,18 +56,28 @@ public struct HwpPage: Sendable, Hashable {
         self.memoPanel = memoPanel
     }
 
-    /// paintList contributes only commands.count (structural fingerprint); its CF
-    /// payloads (NSAttributedString/CGImage/CGPath/CGColor) are not Equatable, so
-    /// pages with same count but different rendered content compare equal.
+    /// 등가는 렌더 산출이 아니라 **구조**로 판정한다 — size·margins·blocks·
+    /// pageNumber와 메모 패널 기하 (width·contentHeight). `paintList`는 어느 항에도
+    /// 들어가지 않는다 (#72).
+    ///
+    /// 본문 paint 커맨드는 blocks의 파생값이라 판별력을 더하지 못하고
+    /// (`AnyHwpBlock.==`가 frame·kind·payload·문자열을 이미 비교한다), CF 페이로드
+    /// (NSAttributedString/CGImage/CGPath/CGColor)는 Equatable이 아니라 애초에
+    /// 커맨드 **개수** 말고는 비교할 수단도 없었다.
+    ///
+    /// 메모 풍선 텍스트는 blocks에 표현이 없어 파생값이 아니지만, 풍선마다 누적한
+    /// `contentHeight`가 풍선 수와 본문 줄 수를 함께 움직인다. 풍선 수가 달라지는데
+    /// `contentHeight`가 우연히 같은 잔여 케이스는 수용한다.
+    ///
+    /// 렌더 결과 확인에 이 `==`를 쓰지 말 것 — 여기서 같다는 것은 조판 구조가 같다는
+    /// 뜻이지 같은 픽셀이 나온다는 뜻이 아니다.
     public func hash(into hasher: inout Hasher) {
         hasher.combine(size.width)
         hasher.combine(size.height)
         hasher.combine(margins)
         hasher.combine(blocks)
         hasher.combine(pageNumber)
-        hasher.combine(paintList.commands.count)
         hasher.combine(memoPanel?.width ?? 0)
-        hasher.combine(memoPanel?.paintList.commands.count ?? 0)
         hasher.combine(memoPanel?.contentHeight ?? 0)
     }
 
@@ -76,10 +86,7 @@ public struct HwpPage: Sendable, Hashable {
             && lhs.margins == rhs.margins
             && lhs.blocks == rhs.blocks
             && lhs.pageNumber == rhs.pageNumber
-            && lhs.paintList.commands.count == rhs.paintList.commands.count
             && lhs.memoPanel?.width == rhs.memoPanel?.width
-            && lhs.memoPanel?.paintList.commands.count
-            == rhs.memoPanel?.paintList.commands.count
             && lhs.memoPanel?.contentHeight == rhs.memoPanel?.contentHeight
     }
 }

--- a/Sources/HwpKitCore/Paint/HwpPaintListBuilder.swift
+++ b/Sources/HwpKitCore/Paint/HwpPaintListBuilder.swift
@@ -15,7 +15,7 @@ public struct HwpPaintListBuilder: Sendable {
         self.imageStore = imageStore
     }
 
-    public func build(for page: HwpPage, index _: HwpIndex) -> HwpPaintList {
+    public func build(for page: HwpPage) -> HwpPaintList {
         var commands: [HwpPaintCommand] = []
         // 같은 구분선을 공유하는 각주 블록들에서 한 번만 그린다.
         // (미주 블록은 자기 위치의 구분선을 따로 가진다.)

--- a/Sources/HwpKitCore/Tuning/HwpRenderTuning.swift
+++ b/Sources/HwpKitCore/Tuning/HwpRenderTuning.swift
@@ -8,8 +8,7 @@ import Foundation
 /// 대조가 필수이고, `HwpRenderTuningTests`의 값 핀도 함께 갱신해야 한다.
 ///
 /// 여기 없는 실측 상수: `HwpChartPainter`의 차트 투영 기하 (상호 결합
-/// 실측 모델이라 in-place 유지), `HwpPaginator`의 각주 예약 근사 (산식
-/// 교체 예정).
+/// 실측 모델이라 in-place 유지).
 public enum HwpRenderTuning {
     /// 본문 텍스트 조판·장식
     public enum Text {

--- a/Sources/HwpKitCore/Utils/HwpColor+CGColor.swift
+++ b/Sources/HwpKitCore/Utils/HwpColor+CGColor.swift
@@ -7,4 +7,8 @@ public extension CGColor {
     static let hwpBlack: CGColor = .init(srgbRed: 0, green: 0, blue: 0, alpha: 1)
     /// Default fill color for textbox backgrounds.
     static let hwpWhite: CGColor = .init(srgbRed: 1, green: 1, blue: 1, alpha: 1)
+    /// 변경 추적 표시색 — 삽입·삭제 글자와 왼쪽 여백 변경 막대가 함께 쓴다.
+    /// 실측 튜닝 상수가 아니라 UI 색 리터럴이라 `HwpRenderTuning`이 아니라
+    /// 여기 산다 (fidelity 게이트 대상이 아니다).
+    static let hwpTrackChange: CGColor = .init(srgbRed: 0.87, green: 0.14, blue: 0.1, alpha: 1)
 }

--- a/Tests/HwpKitCoreTests/HwpFootnotePaintListTests.swift
+++ b/Tests/HwpKitCoreTests/HwpFootnotePaintListTests.swift
@@ -132,7 +132,7 @@ final class HwpFootnotePaintListTests: XCTestCase {
         )
 
         let commands = HwpPaintListBuilder(fontResolver: .testDeterministic)
-            .build(for: page, index: HwpIndex(from: CoreHwp.HwpFile())).commands
+            .build(for: page).commands
         let linkRects = commands.compactMap { command -> CGRect? in
             guard case let .hyperlink(rect, url) = command,
                   url == "https://example.com/wrapped-object"
@@ -266,7 +266,7 @@ final class HwpFootnotePaintListTests: XCTestCase {
             pageNumber: 1
         )
         return HwpPaintListBuilder(fontResolver: .testDeterministic)
-            .build(for: page, index: HwpIndex(from: CoreHwp.HwpFile()))
+            .build(for: page)
             .commands
             .compactMap { command in
                 guard case let .hyperlink(rect, commandURL) = command, commandURL == url
@@ -276,7 +276,6 @@ final class HwpFootnotePaintListTests: XCTestCase {
     }
 
     private let builder = HwpPaintListBuilder()
-    private lazy var index = HwpIndex(from: HwpFile())
 
     func testFootnoteImagePayloadEmitsImageReference() {
         let blockFrame = CGRect(x: 72, y: 700, width: 400, height: 60)
@@ -418,7 +417,7 @@ final class HwpFootnotePaintListTests: XCTestCase {
         _ footnote: HwpFootnoteBlock, frame: CGRect
     ) -> [HwpPaintCommand] {
         let block = AnyHwpBlock(frame: frame, kind: .footnote, payload: .footnote(footnote))
-        return builder.build(for: makePage(blocks: [block]), index: index).commands
+        return builder.build(for: makePage(blocks: [block])).commands
     }
 
     private func makePage(blocks: [AnyHwpBlock]) -> HwpPage {

--- a/Tests/HwpKitCoreTests/HwpHyperlinkPipelineTests.swift
+++ b/Tests/HwpKitCoreTests/HwpHyperlinkPipelineTests.swift
@@ -204,7 +204,7 @@ final class HwpHyperlinkPipelineTests: XCTestCase {
         let page = makePage(with: [block])
 
         let paintList = HwpPaintListBuilder()
-            .build(for: page, index: HwpIndex(from: CoreHwp.HwpFile()))
+            .build(for: page)
 
         let hyperlinkCommand = paintList.commands.first { command in
             if case .hyperlink = command {
@@ -229,7 +229,7 @@ final class HwpHyperlinkPipelineTests: XCTestCase {
         let page = makePage(with: [plain])
 
         let paintList = HwpPaintListBuilder()
-            .build(for: page, index: HwpIndex(from: CoreHwp.HwpFile()))
+            .build(for: page)
 
         let hasHyperlink = paintList.commands.contains { command in
             if case .hyperlink = command {
@@ -272,7 +272,7 @@ final class HwpHyperlinkPipelineTests: XCTestCase {
         let page = makePage(with: [block])
 
         let paintList = HwpPaintListBuilder()
-            .build(for: page, index: HwpIndex(from: CoreHwp.HwpFile()))
+            .build(for: page)
         let linkRects: [CGRect] = paintList.commands.compactMap { command in
             if case let .hyperlink(rect, url) = command, url == "https://example.com" {
                 return rect

--- a/Tests/HwpKitCoreTests/HwpObjectAnchorGeometryTests.swift
+++ b/Tests/HwpKitCoreTests/HwpObjectAnchorGeometryTests.swift
@@ -1,0 +1,118 @@
+import CoreGraphics
+@testable import CoreHwp
+import Foundation
+@testable import HwpKitCore
+import Nimble
+import XCTest
+
+/// 개체 앵커 산식의 분기 핀 (#73).
+///
+/// 이 산식은 페이지 흐름 경로와 컨테이너 수집 경로가 **공유**한다. 종전에는
+/// 두 곳에 같은 구현이 따로 있었고, 픽스처가 닿는 것은 `topOrLeft`/nil 분기뿐이라
+/// 나머지 정렬 분기는 어느 게이트도 잡지 못했다 — 실제로 `.center` 분기를 1pt
+/// 틀어도 블록 스냅샷과 렌더 해시가 모두 초록이었다. 공유 소유자로 합치면서
+/// 그 구멍을 여기서 닫는다.
+final class HwpObjectAnchorGeometryTests: XCTestCase {
+    // MARK: aligned — 정렬 분기 전수
+
+    func testTopOrLeftKeepsBase() {
+        let value = aligned(alignment: .topOrLeft)
+        expect(value) == 100
+    }
+
+    func testInsideKeepsBase() {
+        let value = aligned(alignment: .inside)
+        expect(value) == 100
+    }
+
+    func testNilAlignmentKeepsBase() {
+        let value = aligned(alignment: nil)
+        expect(value) == 100
+    }
+
+    /// base + (extent − size) / 2 — 픽스처가 닿지 않는 분기.
+    func testCenterCentersWithinExtent() {
+        let value = aligned(alignment: .center)
+        expect(value) == 130
+    }
+
+    /// base + extent − size — 픽스처가 닿지 않는 분기.
+    func testBottomOrRightPinsToFarEdge() {
+        let value = aligned(alignment: .bottomOrRight)
+        expect(value) == 160
+    }
+
+    func testOutsidePinsToFarEdge() {
+        let value = aligned(alignment: .outside)
+        expect(value) == 160
+    }
+
+    // MARK: extent 규칙
+
+    /// extent가 0이면 정렬이 무효다 — 페이지 경로가 세로 기준 '문단'일 때
+    /// extent 0을 넘겨 정렬을 끄는 것이 이 규칙에 기댄다.
+    func testZeroExtentDisablesAlignment() {
+        for alignment: CoreHwp.HwpCommonCtrlRelativeAlignment in
+            [.center, .bottomOrRight, .outside, .topOrLeft, .inside]
+        {
+            let value = HwpObjectAnchorGeometry.aligned(
+                base: 100, extent: 0, size: 20, alignment: alignment
+            )
+            expect(value) == 100
+        }
+    }
+
+    func testNegativeExtentDisablesAlignment() {
+        let value = HwpObjectAnchorGeometry.aligned(
+            base: 100, extent: -50, size: 20, alignment: .center
+        )
+        expect(value) == 100
+    }
+
+    /// 개체가 여유 폭보다 크면 center는 base보다 앞으로 나간다 — 클램프하지
+    /// 않는 것이 현재 동작이고, 흐름 경로가 따로 페이지 안으로 되돌린다.
+    func testOversizedObjectIsNotClamped() {
+        let value = HwpObjectAnchorGeometry.aligned(
+            base: 100, extent: 40, size: 100, alignment: .center
+        )
+        expect(value) == 70
+    }
+
+    // MARK: inlineAnchorOrigin
+
+    /// 세로는 baseline − ascent = 개체 상단이고, baseline은 문단 첫 줄의
+    /// baseline에 그 줄의 origin.y를 더한 값이다.
+    func testInlineAnchorOriginUsesFirstBaselineMinusAscent() {
+        let origin = HwpObjectAnchorGeometry.inlineAnchorOrigin(
+            paragraphOrigin: CGPoint(x: 10, y: 20),
+            firstBaseline: 12,
+            lineOrigin: CGPoint(x: 3, y: 30),
+            xOffset: 5,
+            ascent: 9
+        )
+        expect(origin.x) == 18 // 10 + 3 + 5
+        expect(origin.y) == 53 // 20 + 12 + 30 − 9
+    }
+
+    func testInlineAnchorOriginAtParagraphOriginWithZeroMetrics() {
+        let origin = HwpObjectAnchorGeometry.inlineAnchorOrigin(
+            paragraphOrigin: .zero,
+            firstBaseline: 0,
+            lineOrigin: .zero,
+            xOffset: 0,
+            ascent: 0
+        )
+        expect(origin) == .zero
+    }
+
+    // MARK: 헬퍼
+
+    /// base 100 · extent 80 · size 20 고정 — 분기별 기대값이 100/130/160.
+    private func aligned(
+        alignment: CoreHwp.HwpCommonCtrlRelativeAlignment?
+    ) -> CGFloat {
+        HwpObjectAnchorGeometry.aligned(
+            base: 100, extent: 80, size: 20, alignment: alignment
+        )
+    }
+}

--- a/Tests/HwpKitCoreTests/HwpPageEqualityContractTests.swift
+++ b/Tests/HwpKitCoreTests/HwpPageEqualityContractTests.swift
@@ -1,0 +1,154 @@
+import CoreGraphics
+import Foundation
+@testable import HwpKitCore
+import Nimble
+import XCTest
+
+/// `HwpPage.==` / `hash` 의 계약을 고정한다 (#72 조각 ①).
+///
+/// 이 동등성은 렌더 갱신 스킵만 가르는 것이 아니라 **선택 지오메트리 재생성**과
+/// **검색 재스캔 생략**(`HwpGeometryChange.isEquivalentRefresh`)의 입력이다.
+/// 종전에는 `paintList.commands.count` 를 항으로 들고 있었는데, 그 항을 잠그는
+/// 테스트가 저장소 전체에 0건이라 빼도 넣어도 아무것도 빨개지지 않았다.
+final class HwpPageEqualityContractTests: XCTestCase {
+    // MARK: paint 항이 동등성에 없다
+
+    /// 커맨드 수만 다른 두 페이지는 **같다** — paint 커맨드는 blocks 의
+    /// 파생값이라 판별력을 더하지 못한다.
+    func testPagesDifferingOnlyInPaintCommandCountAreEqual() {
+        let bare = makePage(commandCount: 0)
+        let painted = makePage(commandCount: 7)
+        expect(bare) == painted
+        expect(bare.hashValue) == painted.hashValue
+    }
+
+    /// 메모 패널의 커맨드 수만 달라도 같다 — 풍선 수·줄 수는 패널 기하
+    /// (`width`·`contentHeight`)가 대신 나른다.
+    func testPagesDifferingOnlyInMemoPanelCommandCountAreEqual() {
+        let thin = makePage(commandCount: 0, memoCommandCount: 1)
+        let thick = makePage(commandCount: 0, memoCommandCount: 9)
+        expect(thin) == thick
+    }
+
+    // MARK: 구조 항은 그대로 판별한다
+
+    func testBlocksStillBreakEquality() {
+        let text = AnyHwpBlock(frame: .zero, kind: .text)
+        let other = AnyHwpBlock(frame: CGRect(x: 1, y: 2, width: 3, height: 4), kind: .text)
+        let textPage = makePage(blocks: [text])
+        let otherPage = makePage(blocks: [other])
+        expect(textPage) != otherPage
+    }
+
+    func testPageNumberStillBreaksEquality() {
+        let first = makePage(pageNumber: 1)
+        let second = makePage(pageNumber: 2)
+        expect(first) != second
+    }
+
+    /// 메모 패널 기하는 남는다 — 풍선 텍스트는 blocks 에 표현이 없어
+    /// 이 두 항이 빠지면 메모 변화를 나를 것이 아무것도 없다.
+    func testMemoPanelGeometryStillBreaksEquality() {
+        let narrow = makePage(memoWidth: 100)
+        let wide = makePage(memoWidth: 140)
+        expect(narrow) != wide
+
+        let short = makePage(memoContentHeight: 50)
+        let tall = makePage(memoContentHeight: 90)
+        expect(short) != tall
+    }
+
+    // MARK: 검색 재스캔 생략과의 연결
+
+    /// 커맨드 수만 다른 재전달은 이제 **등가 재전달**로 보고된다 —
+    /// `HwpSearchController` 가 이 플래그를 보고 전량 재스캔을 생략한다.
+    /// paint 항이 `==` 에 있던 시절에는 등가가 아니어서 매번 재스캔이 돌았다.
+    ///
+    /// nil-token 문서를 쓰는 이유: 토큰이 있으면 `setDocument` 이 `==` 를 믿고
+    /// **아예 조기 반환**해 콜백 자체가 뜨지 않는다 (그 경로는 아래 테스트).
+    @MainActor
+    func testPaintOnlyRedeliveryIsReportedAsEquivalentRefresh() {
+        let controller = HwpSelectionController()
+        var changes: [HwpGeometryChange] = []
+        controller.onGeometryChanged = { changes.append($0) }
+
+        controller.setDocument(makeDocument(commandCount: 3), preservingSelection: false)
+        controller.setDocument(makeDocument(commandCount: 11), preservingSelection: false)
+        expect(changes.last?.isEquivalentRefresh) == true
+
+        // 구조가 달라진 재전달은 등가가 아니다 — 재스캔이 돌아야 한다.
+        controller.setDocument(
+            makeDocument(commandCount: 11, pageNumber: 2), preservingSelection: false
+        )
+        expect(changes.last?.isEquivalentRefresh) == false
+    }
+
+    /// 토큰이 있는 문서라면 커맨드 수만 다른 재전달은 지오메트리 재생성 자체를
+    /// 건너뛴다. 조판 구조가 같으므로 새로 만들어 봐야 같은 지오메트리다.
+    @MainActor
+    func testTokenedPaintOnlyRedeliveryIsSkippedEntirely() {
+        let token = UUID()
+        let controller = HwpSelectionController()
+        controller.setDocument(
+            makeDocument(commandCount: 3, loadToken: token), preservingSelection: false
+        )
+
+        var changes: [HwpGeometryChange] = []
+        controller.onGeometryChanged = { changes.append($0) }
+        controller.setDocument(
+            makeDocument(commandCount: 11, loadToken: token), preservingSelection: false
+        )
+        expect(changes).to(beEmpty())
+    }
+
+    // MARK: 헬퍼
+
+    private func makePage(
+        blocks: [AnyHwpBlock] = [AnyHwpBlock(frame: .zero, kind: .text)],
+        pageNumber: Int = 1,
+        commandCount: Int = 0,
+        memoCommandCount: Int? = nil,
+        memoWidth: CGFloat? = nil,
+        memoContentHeight: CGFloat? = nil
+    ) -> HwpPage {
+        let memoPanel: HwpMemoPanel? =
+            if memoCommandCount != nil || memoWidth != nil || memoContentHeight != nil {
+                HwpMemoPanel(
+                    width: memoWidth ?? 120,
+                    paintList: paintList(commandCount: memoCommandCount ?? 0),
+                    contentHeight: memoContentHeight ?? 0
+                )
+            } else {
+                nil
+            }
+        return HwpPage(
+            size: CGSize(width: 595, height: 842),
+            margins: HwpPageMargins(top: 10, left: 10, bottom: 10, right: 10),
+            blocks: blocks,
+            pageNumber: pageNumber,
+            paintList: paintList(commandCount: commandCount),
+            memoPanel: memoPanel
+        )
+    }
+
+    private func paintList(commandCount: Int) -> HwpPaintList {
+        HwpPaintList(commands: (0 ..< commandCount).map { index in
+            .fillRect(
+                rect: CGRect(x: CGFloat(index), y: 0, width: 1, height: 1),
+                color: .hwpBlack
+            )
+        })
+    }
+
+    private func makeDocument(
+        commandCount: Int,
+        pageNumber: Int = 1,
+        loadToken: UUID? = nil
+    ) -> HwpDocument {
+        HwpDocument(
+            pages: [makePage(pageNumber: pageNumber, commandCount: commandCount)],
+            metadata: HwpDocumentMetadata(pageCount: 1, loadToken: loadToken),
+            unsupportedElements: []
+        )
+    }
+}

--- a/Tests/HwpKitCoreTests/HwpPaginatorCancellationTests.swift
+++ b/Tests/HwpKitCoreTests/HwpPaginatorCancellationTests.swift
@@ -1,0 +1,93 @@
+@testable import CoreHwp
+import Foundation
+@testable import HwpKitCore
+import Nimble
+import XCTest
+
+#if canImport(CoreText)
+    /// 페이지네이션 취소 응답 — `Task.yield()` 배칭(#73 조각 3)이 취소 관찰을
+    /// 늦추지 않음을 고정한다.
+    ///
+    /// 배칭 전에는 문단마다 양보했으므로 취소가 늦어도 한 문단 안에 관찰됐다.
+    /// 배칭 후에는 양보가 `HwpPaginator.yieldBatchSize` 문단마다 한 번인데,
+    /// **취소 관찰은 양보가 아니라 `Task.checkCancellation()`이 한다** — 그것은
+    /// `processParagraph`가 문단마다 그대로 부른다. 이 스위트가 그 분리를 잠근다.
+    ///
+    /// `HwpPaginator`가 도는 동안 취소가 관찰되는지를 보는 저장소 최초의 테스트다
+    /// (종전에는 `HwpKitNative`의 액터 스모크뿐이었다).
+    final class HwpPaginatorCancellationTests: XCTestCase {
+        /// 취소하면 `page(at:)`이 `CancellationError`로 끝난다 — 문서 끝까지
+        /// 조판하고 나서가 아니라.
+        func testCancelDuringPaginationThrowsCancellationError() async throws {
+            let paginator = makePaginator(paragraphCount: 4000)
+
+            let task = Task {
+                // 마지막 페이지보다 훨씬 뒤 — 취소가 없으면 전량 조판해야 닿는다.
+                try await paginator.page(at: 100_000)
+            }
+            // 조판이 실제로 시작하도록 한 틱 넘긴 뒤 취소한다.
+            await Task.yield()
+            task.cancel()
+
+            do {
+                _ = try await task.value
+                fail("취소했는데 CancellationError가 아니라 정상 반환했다")
+            } catch is CancellationError {
+                // 기대 경로
+            } catch {
+                fail("CancellationError가 아니라 \(error)")
+            }
+        }
+
+        /// 취소는 문서를 끝까지 조판하기 전에 관찰된다 — 배칭이 취소를
+        /// "문서 끝까지 밀어 버리지" 않음을 페이지 수로 확인한다.
+        func testCancelStopsBeforePaginatingWholeDocument() async {
+            let paragraphCount = 4000
+            let paginator = makePaginator(paragraphCount: paragraphCount)
+
+            let task = Task { try await paginator.page(at: 100_000) }
+            await Task.yield()
+            task.cancel()
+            _ = try? await task.value
+
+            // 전량 조판했다면 문단 수 / 페이지당 줄 수 만큼 페이지가 생긴다.
+            let fullDocumentPages = paragraphCount / linesPerPage
+            let produced = await paginator.cachedPages.count
+            expect(produced) < fullDocumentPages
+        }
+
+        /// 취소하지 않으면 같은 문서가 끝까지 조판된다 — 위 두 테스트가
+        /// "그냥 아무것도 안 해서" 통과하는 것이 아님을 잠근다.
+        func testUncancelledPaginationCompletes() async {
+            let paragraphCount = 400
+            let paginator = makePaginator(paragraphCount: paragraphCount)
+            let totalPages = await paginator.totalPages()
+            expect(totalPages) >= paragraphCount / linesPerPage
+        }
+
+        // MARK: 헬퍼
+
+        private let linesPerPage = 34
+
+        private func makePaginator(paragraphCount: Int) -> HwpPaginator {
+            let bodyParagraphs = (0 ..< paragraphCount).compactMap { index in
+                try? HwpSynthetic.lineSegParagraph(
+                    "제\(index)문단 가나다라마바사아자차카타파하 취소 응답 계측 본문",
+                    segments: [(
+                        location: Int32(2720 + (index % linesPerPage) * 2100),
+                        height: 1500
+                    )]
+                )
+            }
+            let section = HwpSynthetic.section(
+                firstParagraphControls: [.section(HwpSynthetic.sectionDef())],
+                bodyParagraphs: bodyParagraphs
+            )
+            return HwpPaginator(
+                sections: [section],
+                index: HwpIndex(from: CoreHwp.HwpFile()),
+                fontResolver: .testDeterministic
+            )
+        }
+    }
+#endif

--- a/Tests/HwpKitCoreTests/HwpPaintListBuilderTests.swift
+++ b/Tests/HwpKitCoreTests/HwpPaintListBuilderTests.swift
@@ -7,7 +7,6 @@ import XCTest
 
 final class HwpPaintListBuilderTests: XCTestCase {
     private let builder = HwpPaintListBuilder()
-    private lazy var index = HwpIndex(from: HwpFile())
 
     /// 절단면 클립이 있는 셀 그림은 저작 rect를 유지한 채 페이지 좌표로
     /// 오프셋된 clipRect로 방출된다 (R32 #2).
@@ -40,7 +39,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             kind: .table,
             payload: .table(table)
         )
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
 
         let clips: [(CGRect, CGRect?)] = list.commands.compactMap {
             if case let .drawImageReference(_, rect, _, clip) = $0 {
@@ -54,7 +53,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
     }
 
     func testEmptyPageProducesNoCommands() {
-        let list = builder.build(for: makePage(blocks: []), index: index)
+        let list = builder.build(for: makePage(blocks: []))
         expect(list.commands.count) == 0
     }
 
@@ -64,7 +63,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             kind: .text,
             attributedString: NSAttributedString(string: "hello")
         )
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         expect(list.commands.count) >= 1
         guard case .drawText = list.commands[0] else {
             fail("Expected .drawText as first command")
@@ -74,7 +73,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
 
     func testTextBlockWithoutTextProducesNoCommands() {
         let block = AnyHwpBlock(frame: CGRect(x: 72, y: 72, width: 400, height: 20), kind: .text)
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         expect(list.commands.count) == 0
     }
 
@@ -83,7 +82,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             frame: CGRect(x: 72, y: 100, width: 200, height: 100),
             kind: .placeholder
         )
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         expect(list.commands.count) == 1
         guard case .drawPlaceholder = list.commands[0] else {
             fail("Expected .drawPlaceholder")
@@ -93,7 +92,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
 
     func testShapeBlockWithoutPayloadProducesDrawPath() {
         let block = AnyHwpBlock(frame: CGRect(x: 72, y: 200, width: 100, height: 100), kind: .shape)
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         expect(list.commands.count) >= 1
         guard case .drawPath = list.commands[0] else {
             fail("Expected .drawPath")
@@ -113,7 +112,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             kind: .shape,
             payload: .shape(geometry)
         )
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         expect(list.commands.count) == 1
         guard case let .drawPath(path, _, _, strokeWidth) = list.commands[0] else {
             fail("Expected .drawPath")
@@ -127,7 +126,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
 
     func testImageBlockWithoutPayloadProducesPlaceholder() {
         let block = AnyHwpBlock(frame: CGRect(x: 72, y: 300, width: 200, height: 150), kind: .image)
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         expect(list.commands.count) >= 1
         let hasPlaceholder = list.commands.contains {
             if case .drawPlaceholder = $0 {
@@ -150,7 +149,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             kind: .image,
             payload: .image(HwpImageBlockInfo(binItemId: 1))
         )
-        let list = storeBuilder.build(for: makePage(blocks: [block]), index: index)
+        let list = storeBuilder.build(for: makePage(blocks: [block]))
         guard case let .drawImageReference(binItemId, rect, style, _) = list.commands.first else {
             fail("Expected .drawImageReference")
             return
@@ -166,7 +165,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             kind: .image,
             payload: .image(HwpImageBlockInfo(binItemId: 9))
         )
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         guard case let .drawPlaceholder(_, text) = list.commands.first else {
             fail("Expected .drawPlaceholder for missing image data")
             return
@@ -198,7 +197,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             kind: .table,
             payload: .table(table)
         )
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
 
         let fillRects = list.commands.filter {
             if case .fillRect = $0 {
@@ -218,7 +217,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
 
     func testTableBlockWithoutPayloadOrTextProducesNoCommands() {
         let block = AnyHwpBlock(frame: CGRect(x: 72, y: 400, width: 300, height: 200), kind: .table)
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         expect(list.commands.count) == 0
     }
 
@@ -235,7 +234,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             kind: .textbox,
             payload: .textbox(textbox)
         )
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         expect(list.commands.count) == 2
         guard case .fillRect = list.commands[0] else {
             fail("Expected .fillRect as first command")
@@ -263,7 +262,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             kind: .textbox,
             payload: .textbox(textbox)
         )
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         // 테두리 정보가 없으면 배경 + 텍스트만 (기본 테두리 없음 — CCL 한글.app 실측)
         expect(list.commands.count) == 2
         guard case let .drawText(attributed, _, _) = list.commands[1] else {
@@ -285,7 +284,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
             separatorLine: CGRect(x: 72, y: 690, width: 150, height: 1)
         )
         let block = AnyHwpBlock(frame: blockFrame, kind: .footnote, payload: .footnote(footnote))
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
         expect(list.commands.count) == 2
         guard case .fillRect = list.commands[0] else {
             fail("Expected .fillRect separator as first command")
@@ -313,7 +312,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
         )
         let blockFrame = CGRect(x: 72, y: 100, width: 200, height: 80)
         let block = AnyHwpBlock(frame: blockFrame, kind: .textbox, payload: .textbox(textbox))
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
 
         let hyperlinks = list.commands.compactMap { command -> (rect: CGRect, url: String)? in
             if case let .hyperlink(rect, url) = command {
@@ -355,7 +354,7 @@ final class HwpPaintListBuilderTests: XCTestCase {
         )
         let blockFrame = CGRect(x: 72, y: 100, width: 200, height: 80)
         let block = AnyHwpBlock(frame: blockFrame, kind: .textbox, payload: .textbox(textbox))
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
 
         let fallbackRect = paragraphRect.offsetBy(dx: blockFrame.minX, dy: blockFrame.minY)
         let hyperlinkRects = list.commands.compactMap { command -> CGRect? in
@@ -413,7 +412,7 @@ extension HwpPaintListBuilderTests {
             borderColor: black, borderWidth: 1
         )
         let block = AnyHwpBlock(frame: cellRect, kind: .table, payload: .table(table))
-        let list = builder.build(for: makePage(blocks: [block]), index: index)
+        let list = builder.build(for: makePage(blocks: [block]))
 
         let fills: [CGRect] = list.commands.compactMap {
             if case let .fillRect(rect, _) = $0 {

--- a/Tests/HwpKitCoreTests/Performance/PaintListPerformanceTests.swift
+++ b/Tests/HwpKitCoreTests/Performance/PaintListPerformanceTests.swift
@@ -25,9 +25,7 @@ import XCTest
 
             let clock = ContinuousClock()
             let start = clock.now
-            let paintList = HwpPaintListBuilder().build(
-                for: page, index: HwpIndex(from: CoreHwp.HwpFile())
-            )
+            let paintList = HwpPaintListBuilder().build(for: page)
             let elapsed = clock.now - start
 
             expect(paintList.commands.isEmpty) == false

--- a/Tests/HwpKitTests/HwpSelectableTextPaintParityTests.swift
+++ b/Tests/HwpKitTests/HwpSelectableTextPaintParityTests.swift
@@ -131,7 +131,6 @@ final class HwpSelectableTextPaintParityTests: XCTestCase {
     /// (HwpSelectableText와 같은 계약).
     private static func bodyDrawTextEmissions(in page: HwpPage) -> [TextEmission] {
         let builder = HwpPaintListBuilder()
-        let index = HwpIndex(from: HwpFile())
         var emissions: [TextEmission] = []
         for block in page.blocks where block.role == .body {
             if case .chart = block.payload {
@@ -143,7 +142,7 @@ final class HwpSelectableTextPaintParityTests: XCTestCase {
                 blocks: [block],
                 pageNumber: page.pageNumber
             )
-            for command in builder.build(for: singleBlockPage, index: index).commands {
+            for command in builder.build(for: singleBlockPage).commands {
                 if case let .drawText(attributed, origin, lineWidth) = command {
                     emissions.append(TextEmission(
                         string: attributed.string,


### PR DESCRIPTION
#72에서 지연화와 독립적으로 남은 정리 두 건과 #73의 정리 다섯 건을 함께 반영합니다. 조판 산식은 바뀌지 않았고, 렌더 픽셀은 **양 폰트 모드의 모든 픽스처·모든 페이지에서 동일**합니다. 상시 렌더 가드도 기준선 재기록 없이 통과했습니다.

Closes #72
Closes #73

## 배경

두 이슈의 구현이 `HwpPaginator.swift`에서, 문서 변경이 `Sources/HwpKitCore/AGENTS.md`에서 맞물려 구현을 한 커밋으로 정리했습니다. 문서 동기화는 별도 커밋으로 분리했습니다.

각 항목의 근거와 파일·줄 번호 인용은 #72·#73 본문에 있습니다. 이 PR 본문에서는 **이슈의 제안과 실제 반영 내용의 차이**, 검증 결과와 검토에서 확인된 한계를 다룹니다.

## 변경 내용

### #72 — 지연화는 제외하고 연관 정리 두 건만 반영

| 조각 | 내용 |
|---|---|
| ① `HwpPage.==`/`hash`에서 `paintList` 항 제외 | `HwpPage`의 기본 조판 경로에서 본문 `paintList`는 `blocks`를 주 입력으로 만들어지고, 기존 동등성도 `paintList` 페이로드가 아니라 커맨드 수만 비교해 추가 판별력이 제한적이었습니다. 메모 패널은 `paintList` 대신 `width`·`contentHeight`로 기하 변화를 판별합니다. **계약 테스트를 추가했습니다.** 종전에는 `paintList.commands.count` 항을 직접 검증하는 테스트가 없었습니다. |
| ② `HwpPaintListBuilder.build`의 미사용 `index` 인자 제거 | 412줄 구현 전체에서 `index`는 시그니처 한 줄에만 있었습니다. 호출부 27곳(소스 1 + 테스트 26)을 수정하고, 불필요해진 지역 변수 선언 3개도 제거했습니다. `HwpPaintListBuilder.swift`에는 현재 사용되지 않는 `import CoreHwp`가 남아 있습니다. |

**이슈의 중심이었던 "paint list 지연화"는 제외했습니다.** 반영한 것은 지연화와 독립적인 정리 두 건뿐입니다.

### #73 — 산식 일원화·함수 분해·yield 배칭·주석 정리

| 조각 | 내용 |
|---|---|
| ① 개체 앵커 산식 소유자 일원화 | 페이지 흐름 경로(`HwpPaginator`)와 컨테이너 수집 경로(`HwpParagraphObjectCollector`)가 정렬 좌표(`aligned`)와 줄 앵커 좌표(`inlineAnchorOrigin`)를 각자 구현하고 "같은 산식"이라는 주석으로만 연결하던 것을 `HwpObjectAnchorGeometry`(internal)로 합쳤습니다. 산식 자체는 변경하지 않았습니다. 아울러 `HwpPaginator.consumesFlow` 위임 래퍼를 없애고 호출부가 단일 소유자를 직접 부르도록 했습니다. |
| ② `computeNextPage` 분해 | 문단 처리·측정·문서 끝 처리를 각각 `processParagraph`·`measuredParagraph`·`finishPagination`으로 추출했습니다. 두 함수만 추출하면 문단 루프 본문이 유효 64줄로 남아 경고를 해소하지 못합니다. 이 파일의 `function_body_length` 위반은 **5건 → 4건**으로 줄었습니다. |
| ③ `Task.yield()` 배칭 | 문단 처리 중 두 지점에서 호출하는 `yieldPeriodically()`를 **양보 지점 16회마다 한 번** 실제 양보하도록 바꿨습니다. `yieldCounter`는 문단 수가 아니라 호출 횟수를 세므로, 두 지점을 모두 지나는 일반 문단은 약 8문단마다 양보합니다. 20,000문단이면 해당 두 지점의 스케줄러 왕복이 최대 40,000회에서 2,500회로 줄어듭니다. `processParagraph`의 문단별 `Task.checkCancellation()`과 각주·미주 드레인 루프의 페이지별 확인은 이 주기와 독립적입니다. 다만 신설 `HwpPaginatorCancellationTests`는 자식 작업이 실제 문단을 처리했다는 진행 배리어 없이 취소하므로, 문단별 확인이 관찰된다는 것은 보여도 실제 조판 진행 중 취소 응답까지 보장하지는 않습니다. |
| ④ 현행과 맞지 않는 주석·색 리터럴 정리 | `HwpRenderTuning`의 "각주 예약 근사" 설명(현재는 배치와 같은 산식을 쓰며 소유자도 `HwpFootnoteCoordinator`입니다), `restrictedToPageFrame`의 "재귀" 설명(자기 재귀가 아닙니다), `HwpOutlineCollector`의 "본체(2,800줄)" 설명을 바로잡았습니다. 변경 추적용 빨간색 리터럴 두 곳은 `CGColor.hwpTrackChange`로 모았습니다. |
| ⑤ 낡은 줄 번호 참조 정리 | 코드 주석의 `"문단 루프 389와 동일"` 같은 줄 번호 참조 두 곳을 심볼 이름으로 바꿨습니다. |

문서 동기화는 별도 커밋(`6f91cbb`)입니다. `computeNextPage`와 세 헬퍼로 나눈 문단 루프, 양보/취소 분리, UI 색 리터럴의 위치, 새 가드가 보완한 검증 공백을 `AGENTS.md`에 반영했습니다. 검토 결과 양보 단위를 16문단으로 적은 설명은 구현의 16개 양보 지점과 다르고, `hwpTrackChange`가 fidelity 게이트 대상이 아니라는 설명은 `track-changes` 픽스처의 fidelity 임계와 맞지 않습니다. 또한 앵커 분기 설명은 기존 `.bottomOrRight` 테스트를 누락했고, `HwpPaginator.swift`는 `file_length` 규칙이 비활성화되어 있어 별도 파일이 lint상 필수라는 설명도 맞지 않습니다.

## ⚠️ API 호환성 변경 (`api-breaking`)

자세한 내용은 이 PR의 [`CHANGELOG.md`](https://github.com/sboh1214/hwp-swift/blob/refactor/page-equality-and-paginator-cleanup/CHANGELOG.md) `## Unreleased` 변경 내역에 있습니다. 요약:

**1. `HwpPaintListBuilder.build(for:index:)`에서 `index:` 인자가 제거되었습니다.** (소스 브레이킹)

- *이행*: 호출부에서 `index:` 인자만 지우면 됩니다 — `builder.build(for: page, index: someIndex)` → `builder.build(for: page)`. 넘기던 `HwpIndex`를 다른 곳에서 쓰지 않았다면 해당 값의 선언도 불필요해집니다.

**2. `HwpPage`의 `==`/`hash`가 더 이상 `paintList`를 보지 않습니다.** (소스 브레이킹은 아니지만 **동작이 바뀝니다**)

- 이제 `size`·`margins`·`blocks`·`pageNumber`와 메모 패널 기하(`width`·`contentHeight`)로만 판정합니다.
- *영향*: 커맨드 수만 다른 두 페이지가 이제 **같다고** 판정됩니다. 이 동등성은 렌더 갱신 생략뿐 아니라 **선택 지오메트리 재생성**과 **검색 재스캔 생략**(`HwpGeometryChange.isEquivalentRefresh`)의 입력입니다. 그 경우 재스캔과 지오메트리 재생성이 생략됩니다. 조판 구조가 같으면 지오메트리도 같으므로 의도된 변경입니다.
- 렌더 결과가 다른지 확인하는 데 `HwpPage.==`를 쓰던 코드는 `blocks`나 `paintList.commands`를 직접 순회해야 합니다. 종전에도 커맨드 **개수**만 같으면 통과했으므로 신뢰할 수 없는 방법이었습니다.

**추가된 공개 API (호환성에는 영향 없음)**: `CGColor.hwpTrackChange`. `public extension CGColor` 안에 있어 `hwpBlack`·`hwpWhite`와 마찬가지로 접근 수준이 암묵적으로 `public`입니다. 호환성을 깨는 변경이 아니므로 `### Breaking Changes`에는 넣지 않았지만, 공개 심볼이 하나 추가된 사실을 여기에 적습니다.

## 검증

현재 HEAD(`6f91cbb`)에서 로컬 검증을 다시 실행했고, 이 PR의 GitHub CI도 모두 통과했습니다.

- [x] `swift test` — **2,305 tests, 49 skipped, 0 failures**. 커밋된 기준선을 사용하는 렌더 가드(블록 스냅샷·렌더 골든·페이지 수·각주 겹침)가 **재기록 없이** 통과
- [x] `swiftformat --lint .` (CI와 동일 명령) — 포맷이 필요한 파일 **0/659개**. 로컬 `0.62.1` = CI brew
- [x] `swiftlint` — error **0** (warning 188 → 187). CI lint 작업은 `--strict`를 쓰지 않아 warning은 게이트가 아닙니다

구현 커밋(`1f46c3b`)에 기록된 실측:

- [x] `swift test --filter FixtureBlockLayout` — 블록 스냅샷 **바이트 동일**(재기록 없음)
- [x] `HWP_SNAPSHOT_TESTS=1` 렌더 해시 + PrvImage fidelity — **양 폰트 모드** 무변화, 기준선 재기록 없음
- [x] `swift test --filter HwpLayoutRenderParitySweep` — 측정·렌더 등가 스윕 통과
- [x] `HWP_PERF=1` — N=20,000 → 589쪽 **7.515s** (임계 15s, 배칭 전 ~7.6s)

**가드가 실제로 회귀를 잡는지 변이로 확인했습니다.** `paintList.commands.count` 비교를 되돌리면 관련 계약 테스트가 실패하고, 문단별 `checkCancellation()`을 제거하면 취소 테스트 2건이 실패합니다. 다만 취소 테스트는 한 번의 `Task.yield()` 뒤 취소하며 `page(at:)`와 `computeNextPage()`도 작업 전에 양보하므로, 첫 문단 처리 전에 취소될 수 있습니다. 따라서 변이 결과는 문단별 확인이 테스트에 영향을 준다는 사실은 보여도 실제 조판 진행 중 취소 응답을 입증하지는 않습니다.

변이 검사에서 **`.center` 분기의 렌더 가드 공백을 찾았습니다**. `aligned`의 `.center` 분기를 1pt 틀어도 블록 스냅샷과 렌더 해시가 모두 통과했습니다. `.bottomOrRight`는 기존 `HwpPaginatorColumnCacheTests`가 실제 collector 경로에서 검증하고 있었으므로, 새로 확인된 공백은 `.center`입니다. 합친 산식을 직접 잠그도록 `HwpObjectAnchorGeometryTests`에 정렬 분기 전수와 extent 규칙을 추가했습니다.

## 비목표 / 알려진 한계

- **#72의 paint list 지연화는 제외했습니다.** 이 PR이 반영한 것은 지연화와 독립적인 정리 두 건뿐입니다.
- **컨테이너 경로의 `origin(commonProperty:size:placement:cursorX:)`은 의도적으로 합치지 않았습니다.** 페이지 경로 `anchoredObjectFrame`의 **문단 rect 근사**라 같은 함수가 아닙니다. 두 경로가 공유하는 것은 그 근사 안에서 호출하는 `aligned`뿐입니다.
- **`function_body_length` 위반은 5 → 4이지 0이 아닙니다.** 남은 네 건은 이 PR의 범위 밖입니다.
- **성능은 주장하지 않습니다.** yield 배칭의 A/B는 7.6 → 7.515s로 노이즈와 구분되지 않고, 그 수치를 보장하는 CI 가드도 없습니다. 배칭의 목적은 wall-time이 아니라 양보 지점 기준 스케줄러 왕복(40,000 → 2,500회) 자체를 줄이는 것입니다.
- **`HwpObjectAnchorGeometry`는 `internal`로 둡니다.** 두 내부 경로가 공유하는 산식이지 외부에 공개할 API가 아닙니다.

## 리뷰 포인트

20개 파일을 순서 없이 열면 검토가 길어집니다. 다음 순서를 권합니다.

1. **`Sources/HwpKitCore/Layout/HwpObjectAnchorGeometry.swift`** (신설, 52줄) — 합친 산식의 실체. 문서 주석이 "무엇을 여기 두고 무엇을 두지 않는가"를 설명합니다.
2. **`Sources/HwpKitCore/Model/HwpPage.swift`** — 동등성 판정 단순화. 문서 주석이 각 항을 왜 뺐고 왜 남겼는지 설명합니다.
3. **`Sources/HwpKitCore/Layout/HwpPaginator.swift`** — 문단 루프 분해와 yield 배칭. 구현은 문단이 아니라 양보 지점 16회를 세며, 취소 확인은 별도입니다. 취소 테스트에 실제 진행 배리어가 없다는 한계도 함께 확인해야 합니다.
4. **`Tests/HwpKitCoreTests/HwpPageEqualityContractTests.swift`** (신설) — `paintList` 항이 빠졌다는 사실뿐 아니라 **남은 항이 여전히 판별한다**는 점, 선택 지오메트리 재생성 여부와 검색 재스캔 판단에 전달되는 `isEquivalentRefresh`까지 검증합니다.
5. **`Tests/HwpKitCoreTests/HwpObjectAnchorGeometryTests.swift`** (신설) — 기존 collector 경로의 `.bottomOrRight` 검증과 별개로, 렌더 가드가 놓친 `.center`를 포함해 합친 산식을 직접 검증합니다.
6. **`Sources/HwpKitCore/AGENTS.md`** — 위 계약의 문서화와 함께, 양보 단위·fidelity 대상·앵커 분기 범위 설명이 실제 구현 및 테스트와 다른 부분을 확인할 수 있습니다.
