### PR TITLE
chore(release): 0.16.0 릴리스 준비 - 버전 산정, 설치 안내, 배포 절차 정비

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -285,8 +285,8 @@
         <pre><code>dependencies: [
     .package(url: "https://github.com/sboh1214/hwp-swift.git", .upToNextMinor(from: "0.16.0")),
 ],</code></pre>
-        <p class="note">이 저장소는 1.0 전까지 파괴 변경을 minor 버전에 싣습니다. <code>from:</code>은 다음 minor의 파괴 변경을 자동
-          수용하므로(<code>0.16.0..&lt;1.0.0</code>), <code>.upToNextMinor</code>로 고정하고 minor 업데이트는 <a
+        <p class="note">이 저장소는 1.0 전까지 파괴 변경을 minor 버전에 싣습니다.
+          <code>.upToNextMinor(from: "0.16.0")</code>은 <code>0.16.0..&lt;0.17.0</code>만 허용하므로, minor 버전은 <a
             href="https://github.com/sboh1214/hwp-swift/releases">릴리스 노트</a>를 확인한 뒤 올리는 것을 권장합니다.</p>
       </section>
 

--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -266,7 +266,7 @@
     <main>
       <section aria-labelledby="intro-title">
         <h2 id="intro-title">소개</h2>
-        <p>한글 파일을 읽고 쓰기 위한 스위프트 패키지</p>
+        <p>한글 파일을 읽기 위한 스위프트 패키지</p>
         <p class="note">본 제품은 한글과컴퓨터의 한글 문서 파일(.hwp) 공개 문서를 참고하여 개발하였습니다.</p>
         <p class="note">라이브러리 구조와 공개 형식은 CoreHwp 문서에서 확인할 수 있습니다.</p>
       </section>
@@ -277,9 +277,9 @@
         <p>Xcode에서 <code>File</code> &gt; <code>Swift Packages</code> &gt; <code>Add Package Dependency...</code> 메뉴를 선택하세요.</p>
         <p>또는 의존성을 아래와 같이 수동으로 추가합니다.</p>
         <pre><code>dependencies: [
-    .package(url: "https://github.com/sboh1214/hwp-swift.git", branch: "main"),
+    .package(url: "https://github.com/sboh1214/hwp-swift.git", .upToNextMinor(from: "0.16.0")),
 ],</code></pre>
-        <p class="note">안정 릴리스가 태깅되면 <code>branch: "main"</code> 대신 <code>from: "x.y.z"</code>로 고정하는 것을 권장합니다.</p>
+        <p class="note">이 저장소는 1.0 전까지 파괴 변경을 minor 버전에 싣습니다. <code>from:</code>은 다음 minor의 파괴 변경을 자동 수용하므로(<code>0.16.0..&lt;1.0.0</code>), <code>.upToNextMinor</code>로 고정하고 minor 업데이트는 <a href="https://github.com/sboh1214/hwp-swift/releases">릴리스 노트</a>를 확인한 뒤 올리는 것을 권장합니다.</p>
       </section>
 
       <section aria-labelledby="contributing-title">

--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="ko">
+
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -252,6 +253,7 @@
     }
   </style>
 </head>
+
 <body>
   <div class="page">
     <header class="hero">
@@ -266,20 +268,26 @@
     <main>
       <section aria-labelledby="intro-title">
         <h2 id="intro-title">소개</h2>
-        <p>한글 파일을 읽기 위한 스위프트 패키지</p>
+        <p>한글 파일을 읽고 쓰기 위한 스위프트 패키지</p>
         <p class="note">본 제품은 한글과컴퓨터의 한글 문서 파일(.hwp) 공개 문서를 참고하여 개발하였습니다.</p>
         <p class="note">라이브러리 구조와 공개 형식은 CoreHwp 문서에서 확인할 수 있습니다.</p>
       </section>
 
       <section aria-labelledby="install-title">
         <h2 id="install-title">설치</h2>
-        <p>Apple 플랫폼(macOS 14+ / iOS 17+ / tvOS 17+ / watchOS 10+)은 추가 설치가 필요 없습니다 — 압축 해제에 SDK 내장 <code>Compression</code>을 씁니다. Linux 등 그 외 플랫폼에서는 <strong>zlib</strong>이 필요합니다. 빌드에는 개발 헤더(<code>apt install zlib1g-dev</code>, rpm 계열은 <code>dnf install zlib-devel</code>), 실행에는 zlib 런타임이 있어야 합니다.</p>
-        <p>Xcode에서 <code>File</code> &gt; <code>Swift Packages</code> &gt; <code>Add Package Dependency...</code> 메뉴를 선택하세요.</p>
+        <p>Apple 플랫폼(macOS 14+ / iOS 17+ / tvOS 17+ / watchOS 10+)은 추가 설치가 필요 없습니다 — 압축 해제에 SDK 내장
+          <code>Compression</code>을 씁니다. Linux 등 그 외 플랫폼에서는 <strong>zlib</strong>이 필요합니다. 빌드에는 개발
+          헤더(<code>apt install zlib1g-dev</code>, rpm 계열은 <code>dnf install zlib-devel</code>), 실행에는 zlib 런타임이 있어야 합니다.
+        </p>
+        <p>Xcode에서 <code>File</code> &gt; <code>Swift Packages</code> &gt; <code>Add Package Dependency...</code> 메뉴를
+          선택하세요.</p>
         <p>또는 의존성을 아래와 같이 수동으로 추가합니다.</p>
         <pre><code>dependencies: [
     .package(url: "https://github.com/sboh1214/hwp-swift.git", .upToNextMinor(from: "0.16.0")),
 ],</code></pre>
-        <p class="note">이 저장소는 1.0 전까지 파괴 변경을 minor 버전에 싣습니다. <code>from:</code>은 다음 minor의 파괴 변경을 자동 수용하므로(<code>0.16.0..&lt;1.0.0</code>), <code>.upToNextMinor</code>로 고정하고 minor 업데이트는 <a href="https://github.com/sboh1214/hwp-swift/releases">릴리스 노트</a>를 확인한 뒤 올리는 것을 권장합니다.</p>
+        <p class="note">이 저장소는 1.0 전까지 파괴 변경을 minor 버전에 싣습니다. <code>from:</code>은 다음 minor의 파괴 변경을 자동
+          수용하므로(<code>0.16.0..&lt;1.0.0</code>), <code>.upToNextMinor</code>로 고정하고 minor 업데이트는 <a
+            href="https://github.com/sboh1214/hwp-swift/releases">릴리스 노트</a>를 확인한 뒤 올리는 것을 권장합니다.</p>
       </section>
 
       <section aria-labelledby="contributing-title">
@@ -298,4 +306,5 @@
     </footer>
   </div>
 </body>
+
 </html>

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,6 +18,7 @@ version-resolver:
   minor:
     labels:
       - 'minor'
+      - 'api-breaking'
   patch:
     labels:
       - 'patch'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # 프로젝트 지식 베이스
 
-**Branch:** refactor/shared-line-breaker
-
 ## 개요
 
 한글과컴퓨터의 한글 문서 파일(`.hwp`)을 파싱하고 렌더링하는 Swift package.
@@ -27,7 +25,8 @@ hwp-swift/
 ├── Sample/                # HwpSwiftSample.xcodeproj (xcodegen, path: ..)
 ├── Package.swift          # swift-tools-version:5.9
 ├── .github/workflows/     # ci.yml, cd.yml
-└── .github/pages/         # DocC 사이트 루트 랜딩
+├── .github/pages/         # DocC 사이트 루트 랜딩 (README 설치 안내의 사본)
+└── .github/release-drafter.yml  # 릴리스 노트 분류 + 라벨 → 다음 버전 산정
 ```
 
 폴더명과 파일명은 **공백 없는 PascalCase**를 사용한다 (예:
@@ -251,6 +250,9 @@ Equatable/Hashable에서도 제외된다 (payload **유무** 파생이라 `HwpCh
 - 공백이 있는 새 파일/디렉터리명 추가 — 경로명은 PascalCase + 무공백을 유지.
 - `Package.swift`의 Darwin platform 최소 버전을 더 낮추기 — `SWCompression 4.9.1` / `BitByteData 2.1.0`이 macOS 14+/iOS 17+를 요구한다. #101 이후 이 둘은 테스트 타깃 전용 의존이지만 `platforms:`는 패키지 단위라 하한은 그대로다 (내리려면 압축 해제 기준선부터 갈아야 한다). Linux는 CoreHwp·CoreHwpTests만 지원하며 빌드에 zlib 개발 헤더가 필요하다 (뷰어 타깃은 Apple 전용 프레임워크 의존 — `Package.swift`의 `canImport(Darwin)` 분기; CI matrix: macOS + ubuntu-latest).
 - `swift-tools-version` 변경 시 `.swift-version`, `.swiftformat`, `.github/workflows/ci.yml`의 `test-linux` matrix 동시 갱신 누락 (`CONTRIBUTING.md` 참조).
+- **설치 안내를 한 곳만 고치기** — 같은 스니펫이 `README.md`와 `.github/pages/index.html` 두 곳에 있고, 후자는 `cd.yml`의 `docs` 잡이 DocC 산출물 위에 덮어 배포하는 사이트 랜딩이다 (`cp .github/pages/index.html ./docs/index.html`). README만 고치면 `hwp-swift.sboh.dev`가 낡은 안내를 계속 내보낸다 — 0.16.0 준비에서 실제로 갈렸다 (README는 `.upToNextMinor(from: "0.16.0")`로 옮겼는데 사이트는 `branch: "main"`에 남아 있었다).
+- **PR 라벨 누락·오분류** — 라벨은 릴리스 노트 분류만이 아니라 **다음 버전 번호**를 정한다 (`.github/release-drafter.yml`의 `version-resolver`, 기본 `patch`). 공개 API가 깨지면 `api-breaking`을 달아야 minor로 올라간다 — 1.0 전까지 파괴 변경은 major가 아니라 **minor**에 싣는 규약이므로, 이 라벨이 빠지면 브레이킹 릴리스가 patch 번호로 나간다. 규칙 전문은 `CONTRIBUTING.md`의 "Pull Request 라벨".
+- **모듈별 `version` 상수 재도입** — `HwpKit.version` 같은 상수는 git 태그·`CHANGELOG.md`와 갈리는 두 번째 진실 원본이 된다. 타깃을 처음 만들 때 두었던 스텁 3종(`HwpKit.swift`·`HwpKitCore.swift`·`HwpKitNative.swift`, 각각 `version = "0.1.0-dev"`)은 참조 0건인 채 실제 버전과 어긋난 상태로 남아 있다가 0.16.0 준비에서 제거됐다.
 - 테스트에서 **CoreFoundation 타입에 `as!`** 쓰기 — SwiftFormat의 `noForceUnwrapInTests`가 이를 `try XCTUnwrap(... as? CFType)`으로 자동 변환하는데, CF 타입 대상 `as?`는 컴파일러가 "항상 성공한다"며 **에러**로 막는다. 즉 포매터가 컴파일 불가능한 코드를 만들어 낸다. `// swiftformat:disable:next` 주석도 듣지 않으므로, 캐스트 자체를 없애 우회한다 (컴파일러 note가 제안하는 방식):
   ```swift
   let ref = value as CFTypeRef

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.16.0
+## 0.16.0 (2026-08-24)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.16.0 (2026-08-23)
+
 ### Breaking Changes
 
 - `HwpPaintListBuilder.build(for:index:)` **에서 `index:` 인자가 제거되었습니다.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.16.0 (2026-08-23)
+## 0.16.0
 
 ### Breaking Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,22 @@ python3 -m http.server 8000 --directory /tmp/hwp-preview
 
 ## 배포
 
+### 릴리스
+
+`main`에 푸시될 때마다 release-drafter(`cd.yml`의 `release-drafter` 잡)가 드래프트
+릴리스를 갱신합니다. 다음 버전 번호는 그 구간에 머지된 PR의 라벨에서 산정되므로
+(위 "Pull Request 라벨"), 라벨이 맞아야 번호가 맞습니다.
+
+릴리스할 때 아래를 함께 갱신합니다.
+
+- `CHANGELOG.md` — `## Unreleased` 아래 내용을 `## X.Y.Z (YYYY-MM-DD)`로 확정하고,
+  비어 있는 `## Unreleased`를 맨 위에 남깁니다.
+- `README.md`와 `.github/pages/index.html` — 설치 스니펫의 고정 버전. **두 곳은
+  같은 안내의 사본**이고 후자는 `docs` 잡이 DocC 산출물 위에 덮어 사이트로
+  배포하므로, 하나만 고치면 hwp-swift.sboh.dev가 낡은 안내를 계속 내보냅니다.
+
+드래프트 릴리스를 게시하면 그 시점의 `main`에 태그가 생성됩니다.
+
 ### Swift 버전이 새로 출시된 경우
 
 아래 파일의 Swift matrix를 업데이트합니다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,22 @@ SwiftFormat과 SwiftLint는 모든 PR에서 CI(`ci.yml`의 `lint` 잡)으로 확
 
 커버리지는 [Codecov](https://codecov.io/gh/sboh1214/hwp-swift)에서 추적합니다.
 
+## Pull Request 라벨
+
+라벨은 release-drafter(`.github/release-drafter.yml`)가 릴리스 노트 분류와
+버전 산정에 사용하므로, PR 성격대로 답니다.
+
+- 기능·성능 PR → `enhancement` (릴리스 노트의 🚀 Features로 분류됩니다)
+- 버그 수정 PR → `bug` (성능 관련이면 `performance`를 함께). 버그 수정에는
+  `enhancement`를 달지 않습니다.
+- 문서·CI·테스트·리팩터링 PR → `maintenance`
+- 공개 API의 소스 브레이킹 또는 동작 변경이 있으면 `api-breaking`을 추가로
+  답니다. 이 라벨이 하나라도 든 구간은 다음 릴리스 버전이 minor로 올라갑니다
+  — 1.0 전까지 파괴 변경은 minor 버전에 싣습니다.
+
+라벨이 없는 PR은 릴리스 노트에서 카테고리 밖으로 떨어지므로, 머지 전에
+반드시 하나 이상 답니다.
+
 ## 문서
 
 문서는 [Swift-DocC](https://www.swift.org/documentation/docc/)로 빌드되며,

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ dependencies: [
 ],
 ```
 
-> 이 저장소는 1.0 전까지 파괴 변경을 minor 버전에 싣습니다. `from:`은 다음 minor의 파괴 변경을
-> 자동 수용하므로(`0.16.0..<1.0.0`), `.upToNextMinor`로 고정하고 minor 업데이트는
+> 이 저장소는 1.0 전까지 파괴 변경을 minor 버전에 싣습니다.
+> `.upToNextMinor(from: "0.16.0")`은 `0.16.0..<0.17.0`만 허용하므로, minor 버전은
 > [릴리스 노트](https://github.com/sboh1214/hwp-swift/releases)를 확인한 뒤 올리는 것을 권장합니다.
 
 ## 라이브러리 구조

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ Xcode에서 ```File``` > ```Swift Packages``` > ```Add Package Dependency...``` 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/sboh1214/hwp-swift.git", branch: "main"),
+    .package(url: "https://github.com/sboh1214/hwp-swift.git", .upToNextMinor(from: "0.16.0")),
 ],
 ```
 
-> 안정 릴리스가 태깅되면 `branch: "main"` 대신 `from: "x.y.z"`로 고정하는 것을 권장합니다.
+> 이 저장소는 1.0 전까지 파괴 변경을 minor 버전에 싣습니다. `from:`은 다음 minor의 파괴 변경을
+> 자동 수용하므로(`0.16.0..<1.0.0`), `.upToNextMinor`로 고정하고 minor 업데이트는
+> [릴리스 노트](https://github.com/sboh1214/hwp-swift/releases)를 확인한 뒤 올리는 것을 권장합니다.
 
 ## 라이브러리 구조
 

--- a/Sources/HwpKit/HwpKit.swift
+++ b/Sources/HwpKit/HwpKit.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-public enum HwpKit {
-    public static let version = "0.1.0-dev"
-}

--- a/Sources/HwpKitCore/HwpKitCore.swift
+++ b/Sources/HwpKitCore/HwpKitCore.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-public enum HwpKitCore {
-    public static let version = "0.1.0-dev"
-}

--- a/Sources/HwpKitNative/HwpKitNative.swift
+++ b/Sources/HwpKitNative/HwpKitNative.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-public enum HwpKitNative {
-    public static let version = "0.1.0-dev"
-}


### PR DESCRIPTION
0.16.0 릴리스 직전에 병합되어야 하는 준비 변경입니다. 드래프트 릴리스의 `target_commitish`가 `refs/heads/main`이므로, 게시하면 그 시점의 `main` HEAD에 태그가 생성됩니다. 따라서 이 PR이 먼저 병합되어야 변경 사항이 릴리스에 포함됩니다. 릴리스 절차는 로드맵 #82의 「릴리스」 절에 정리되어 있습니다.

## 배경

마지막 정식 릴리스 `0.15.0`(2026-06-14) 이후 `main`에 664개 커밋이 쌓였고, `CHANGELOG.md`의 `### Breaking Changes`에는 14건이 기록되어 있습니다. 그런데 Release Drafter가 버전 산정에 사용하도록 설정된 `minor`/`major` 라벨은 저장소에 없어 이번 릴리스가 `default: patch`로 계산되었고, 파괴 변경 14건을 포함하고도 `0.15.1`이 매겨졌습니다. `0.15.0` 태그에는 `Sources/CoreHwp`만 포함되어 있어 이번 릴리스는 뷰어 스택(HwpKitCore·HwpKitNative·HwpKit)의 최초 배포이기도 합니다.

## 변경 내용

| 커밋 | 내용 |
|---|---|
| `ci(release)` | `version-resolver.minor.labels`에 저장소에서 사용하는 `api-breaking` 라벨을 추가합니다. 이번 릴리스 구간의 PR 5건(#63·#86·#87·#112·#113)에 이미 붙어 있어, 라벨을 새로 만들거나 수동으로 붙이지 않아도 다음 드래프트 릴리스가 0.16.0으로 재계산됩니다. “1.0 전까지 파괴 변경은 minor 버전에 싣는다”는 정책을 설정에 반영합니다. |
| `chore` | 참조되지 않는 `public static let version = "0.1.0-dev"` 파일 3개(HwpKitCore·HwpKit·HwpKitNative)를 제거합니다. 이 상수를 담은 네임스페이스 enum도 저장소 어디에서도 참조되지 않으며, 어느 릴리스 태그에도 포함된 적이 없습니다. 따라서 0.16.0에 포함되기 전에 제거하는 것은 파괴 변경이 아니지만, 배포 후 제거하면 파괴 변경이 됩니다. |
| `docs(release)` | ① `CHANGELOG.md`의 `## Unreleased`를 `## 0.16.0 (2026-08-24)`으로 확정하고 그 위에 빈 `## Unreleased` 절을 새로 둡니다. ② `README.md`와 사이트 설치 안내를 `branch: "main"`에서 `.upToNextMinor(from: "0.16.0")` 권고로 바꿉니다. 이 요구 사항은 `0.16.0..<0.17.0`만 허용하므로 다음 minor의 파괴 변경을 자동으로 수용하지 않습니다. ③ PR 라벨 규약을 로드맵 이슈에서 `CONTRIBUTING.md`로 옮깁니다. |

<img width="985" height="478" alt="변경된 설치 안내" src="https://github.com/user-attachments/assets/d001c551-b795-480d-91b2-93cfdbc6ef7f" />

같은 절차에 따라 커밋과 별개로 PR #110에 `enhancement` 라벨을 달았습니다. 유일하게 라벨이 없던 PR이라 드래프트 릴리스에서 카테고리 밖의 `$CHANGES`에 포함되어 있었습니다.

## 검증

- [x] `swift build` — 파일 3개 삭제 후 모든 타깃 빌드 성공(상수·enum이 참조되지 않는 것은 `grep -rn`으로 사전 확인)
- [x] Swift 소스는 삭제 외에 수정하지 않아 SwiftFormat 적용 대상 파일이 없었고, pre-commit 훅도 통과
- [ ] `main` 병합 후 실행되는 CD에서 드래프트 릴리스가 0.16.0으로 재계산되는지 확인

## 비목표

- 릴리스 노트 `## Breaking changes` 본문 작성과 게시는 이 PR의 범위에 포함하지 않습니다. 병합 후 드래프트 릴리스의 재계산을 확인하고 진행합니다.
- PR 템플릿 신설은 포함하지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
