### PR TITLE
릴리스 드래프트 템플릿 최신화와 PR 분류 라벨 규칙 정비

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,12 +4,17 @@ categories:
   - title: '🚀 Features'
     labels:
       - 'enhancement'
+  - title: '⚡️ Performances'
+    labels:
+      - 'performance'
   - title: '🐛 Bug Fixes'
     labels:
       - 'bug'
   - title: '🧰 Maintenance'
-    label: 'maintenance'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+    labels:
+      - 'maintenance'
+category-template: '### $TITLE'
+change-template: '- $TITLE — @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
@@ -24,9 +29,11 @@ version-resolver:
       - 'patch'
   default: patch
 template: |
+  ## Changes
+
   ## Breaking changes
   *
 
-  ## Closed Issues & Merged PRs
+  ## Merged PRs
 
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,7 +4,7 @@ categories:
   - title: '🚀 Features'
     labels:
       - 'enhancement'
-  - title: '⚡️ Performances'
+  - title: '⚡️ Performance'
     labels:
       - 'performance'
   - title: '🐛 Bug Fixes'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ SwiftFormat과 SwiftLint는 모든 PR에서 CI(`ci.yml`의 `lint` 잡)으로 확
 버전 산정에 사용하므로, PR 성격대로 답니다.
 
 - 기능 PR → `enhancement` (릴리스 노트의 🚀 Features로 분류됩니다)
-- 성능 개선 PR → `performance` (⚡️ Performances로 분류됩니다)
+- 성능 개선 PR → `performance` (⚡️ Performance로 분류됩니다)
 - 버그 수정 PR → `bug` (🐛 Bug Fixes로 분류됩니다). 성능 회귀 수정도
   `performance`가 아니라 `bug`를 답니다. 버그 수정에는 `enhancement`를
   달지 않습니다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,16 +36,22 @@ SwiftFormat과 SwiftLint는 모든 PR에서 CI(`ci.yml`의 `lint` 잡)으로 확
 라벨은 release-drafter(`.github/release-drafter.yml`)가 릴리스 노트 분류와
 버전 산정에 사용하므로, PR 성격대로 답니다.
 
-- 기능·성능 PR → `enhancement` (릴리스 노트의 🚀 Features로 분류됩니다)
-- 버그 수정 PR → `bug` (성능 관련이면 `performance`를 함께). 버그 수정에는
-  `enhancement`를 달지 않습니다.
-- 문서·CI·테스트·리팩터링 PR → `maintenance`
+- 기능 PR → `enhancement` (릴리스 노트의 🚀 Features로 분류됩니다)
+- 성능 개선 PR → `performance` (⚡️ Performances로 분류됩니다)
+- 버그 수정 PR → `bug` (🐛 Bug Fixes로 분류됩니다). 성능 회귀 수정도
+  `performance`가 아니라 `bug`를 답니다. 버그 수정에는 `enhancement`를
+  달지 않습니다.
+- 문서·CI·테스트·리팩터링 PR → `maintenance` (🧰 Maintenance로 분류됩니다)
 - 공개 API의 소스 브레이킹 또는 동작 변경이 있으면 `api-breaking`을 추가로
   답니다. 이 라벨이 하나라도 든 구간은 다음 릴리스 버전이 minor로 올라갑니다
   — 1.0 전까지 파괴 변경은 minor 버전에 싣습니다.
 
+분류 라벨(`enhancement`·`performance`·`bug`·`maintenance`)은 PR당 하나만
+답니다 — release-drafter는 여러 카테고리에 걸치는 PR을 카테고리마다 중복
+기재합니다. `api-breaking`은 분류 라벨이 아니므로 함께 달아도 됩니다.
+
 라벨이 없는 PR은 릴리스 노트에서 카테고리 밖으로 떨어지므로, 머지 전에
-반드시 하나 이상 답니다.
+반드시 분류 라벨 하나를 답니다.
 
 ## 문서
 


### PR DESCRIPTION
## 변경 내용

`release-drafter` 템플릿을 직접 편집한 0.16.0 릴리스 본문 형식에 맞게 정비합니다.

- 템플릿 맨 앞에 `## Changes`를 추가해 게시 전 요약을 작성할 자리를 둡니다.
- `## Closed Issues & Merged PRs`를 `## Merged PRs`로 바꿉니다. Release Drafter는 이슈가 아니라 병합된 PR을 수집합니다.
- `⚡️ Performance` 카테고리를 추가하고 `performance` 라벨이 달린 PR을 자동 분류합니다.
- `category-template: '### $TITLE'`을 지정해 카테고리를 `## Merged PRs` 아래의 3단계 제목으로 표시합니다. 기본값인 `## $TITLE`을 쓰면 두 제목이 같은 단계가 됩니다.
- `change-template`에 긴 줄표(—)를 추가해 `- 제목 — @작성자 (#번호)` 형식으로 맞춥니다.
- `🧰 Maintenance`의 `label:` 키를 다른 카테고리와 같은 `labels:` 배열로 통일합니다. 동작은 같습니다.
- CONTRIBUTING.md의 "Pull Request 라벨" 절을 새 분류에 맞게 고칩니다. Release Drafter v6는 여러 카테고리 라벨이 달린 PR을 각 카테고리에 중복 기재하므로 분류 라벨(`enhancement`·`performance`·`bug`·`maintenance`)은 PR당 하나만 사용하도록 합니다. 성능 회귀 수정은 `performance`가 아닌 `bug`로 분류합니다.

## 검증

Release Drafter v6 코드(`lib/schema.js`·`lib/releases.js`·`lib/template.js`)를 클론해 이 설정으로 드래프트 생성을 시뮬레이션했습니다.

- v6의 Joi 스키마 검증을 통과했습니다.
- `enhancement`·`performance`·`bug`·`maintenance` 모의 PR로 생성한 본문이 예상한 구조와 정확히 일치했습니다.

```markdown
## Changes

## Breaking changes
*

## Merged PRs

### 🚀 Features

- `HwpFile` 미해석 요소 집계 API와 손상 복구 진단 추가 — @sboh1214 (#111)

### ⚡️ Performance

- `HwpPageLayer`가 조판된 줄을 캐시해 다시 그릴 때 재조판하지 않도록 개선 — @sboh1214 (#89)

### 🐛 Bug Fixes
…
### 🧰 Maintenance
…
```

- `enhancement`와 `performance`를 함께 단 PR이 Features와 Performance 양쪽에 중복 기재되는 것을 확인했습니다. CONTRIBUTING의 새 규칙은 이 동작을 근거로 합니다.
- `## Changes` 문자열은 `$CHANGES` 치환과 간섭하지 않았으며, 백틱을 포함한 PR 제목도 원문대로 유지됐습니다.
- `⚡️`(U+26A1 U+FE0F)와 긴 줄표(U+2014)는 0.16.0 릴리스 본문과 코드 포인트 기준으로 일치했습니다.
- 빈 카테고리는 제목도 생략되므로 성능 PR이 없는 릴리스에는 빈 `### ⚡️ Performance`가 남지 않습니다.
- 리포지토리 전체 검색에서 "Closed Issues" 등 이전 구조를 참조하는 문서가 남아 있지 않음을 확인했습니다.
- `cd.yml`의 `release-drafter@v6` 잡은 기본 경로인 `.github/release-drafter.yml`을 읽으므로 추가 변경이 필요하지 않습니다.

## 참고

- 분류 라벨이 없는 PR은 `## Merged PRs` 바로 아래에서 첫 카테고리 제목보다 먼저, 별도 카테고리 제목 없이 표시됩니다. 기존과 같은 v6 동작입니다. 별도의 "기타" 카테고리에 모으려면 `labels`가 빈 카테고리를 추가하면 됩니다.
- `## Breaking changes` 아래의 `*` 플레이스홀더는 게시 전에 직접 편집하는 기존 방식을 유지했습니다. 드래프트에서는 빈 불릿으로 표시됩니다.