### PR TITLE
HwpTagValidatedRecord 도입으로 record tag 검증 load 중복 제거

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ Equatable/Hashable에서도 제외된다 (payload **유무** 파생이라 `HwpCh
 ## 컨벤션
 
 - **`HwpPrimitive = Codable & Hashable & Sendable`** — 모든 모델이 채택 (typealias는 [`HwpPrimitive.swift`](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/Utils/Protocols/HwpPrimitive.swift)). 전 모델이 값 타입이라 `Sendable`은 자동 충족 — 백그라운드 파싱 → UI 전달이 컴파일러 검증된다.
-- [`Utils/Protocols/`](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/Utils/Protocols/)의 **loader 프로토콜**은 `static load(...)`를 default 구현으로 제공하며 EOF를 강제한다 — reader에 잔여 byte가 있으면 `HwpError.bytesAreNotEOF`를 throw. 채택 측은 `init(_ reader: inout DataReader, ...)`만 작성.
+- [`Utils/Protocols/`](file:///Users/sboh/Repos/hwp-swift/Sources/CoreHwp/Utils/Protocols/)의 **loader 프로토콜**은 `static load(...)`를 default 구현으로 제공하며 EOF를 강제한다 — reader에 잔여 byte가 있으면 `HwpError.bytesAreNotEOF`를 throw. 채택 측은 `init(_ reader: inout DataReader, ...)`만 작성. record 갈래는 **tag 검증까지 default가 흡수한다** — `HwpTagValidatedRecord`(`WithVersion`)를 채택하고 `static let expectedTag`만 선언하면 `load` override가 필요 없다 (#83).
 - public 타입의 **한국어 doc-comment**는 한컴 공개 문서의 절을 참조한다. 편집 시 보존할 것.
 - **`Tests/` 외부에서 `import XCTest` 금지.**
 - **SwiftFormat** (`--swiftversion 5.9 --disable hoistTry`)과 **SwiftLint**가 CI 및 `pre-commit`에서 강제됨.
@@ -246,7 +246,7 @@ Equatable/Hashable에서도 제외된다 (payload **유무** 파생이라 `HwpCh
 ## 안티 패턴 (이 프로젝트 한정)
 
 - 테스트에서 `XCTAssert*` 사용 — SwiftLint custom rule `no_xctassert` (severity: error)로 금지. Nimble `expect(...) == ...` 사용.
-- EOF를 검사하지 않고 silent하게 byte 잔여 — loader 프로토콜의 `load`가 `bytesAreNotEOF`를 throw하도록 설계되어 있으므로, manual `init` 호출로 우회 금지.
+- EOF를 검사하지 않고 silent하게 byte 잔여 — loader 프로토콜의 `load`가 `bytesAreNotEOF`를 throw하도록 설계되어 있으므로, manual `init` 호출로 우회 금지. 승인된 opt-out은 tag-검증 모델의 `enforcesEOF = false` 하나뿐이고, 그것도 #83 이전 커스텀 load가 EOF를 보지 않던 **8종의 현행 동작 동결**이지 설계가 아니다 — 새 타입에서 끄지 말 것 (일괄 강제 전환은 실문서 확인과 함께 후속 이슈).
 - 공백이 있는 새 파일/디렉터리명 추가 — 경로명은 PascalCase + 무공백을 유지.
 - `Package.swift`의 Darwin platform 최소 버전을 더 낮추기 — `SWCompression 4.9.1` / `BitByteData 2.1.0`이 macOS 14+/iOS 17+를 요구한다. #101 이후 이 둘은 테스트 타깃 전용 의존이지만 `platforms:`는 패키지 단위라 하한은 그대로다 (내리려면 압축 해제 기준선부터 갈아야 한다). Linux는 CoreHwp·CoreHwpTests만 지원하며 빌드에 zlib 개발 헤더가 필요하다 (뷰어 타깃은 Apple 전용 프레임워크 의존 — `Package.swift`의 `canImport(Darwin)` 분기; CI matrix: macOS + ubuntu-latest).
 - `swift-tools-version` 변경 시 `.swift-version`, `.swiftformat`, `.github/workflows/ci.yml`의 `test-linux` matrix 동시 갱신 누락 (`CONTRIBUTING.md` 참조).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Changed
+
+- **record tag 검증 보일러플레이트를 loader 프로토콜 default로 흡수했습니다**
+  (#83). `HwpTagValidatedRecord` / `HwpTagValidatedRecordWithVersion`(둘 다
+  internal)을 채택하고 `static let expectedTag`(`HwpSectionTag` 또는
+  `HwpDocInfoTag`)만 선언하면 tag 검증 + reader 생성 + init + EOF 강제를
+  default `load`가 제공합니다. 모델 18개 파일에 흩어져 있던 커스텀 `load` 구현
+  31개와 `// MARK: loader contract exemption` 주석 28개가 사라지고 신설 프로토콜
+  파일(118줄)의 default 구현 6개가 그 자리를 대신해, 파서 소스가 순 126줄
+  줄었습니다. 공개 API·파싱 동작·렌더 산출물은 무변화입니다.
+  - load 반환 직전 `rawPayload`를 record 전체 payload로 복원하던 반복은
+    `HwpRawPayloadRestoringRecord` 표식으로 옮겼습니다. 복원이
+    `preservedPayload` 게이트를 그대로 지나므로 `.viewer` 프리셋의 메모리
+    이득도 유지됩니다 — load 후 `rawPayload`를 다시 읽는 `HwpListControl`은
+    이 표식 대신 커스텀 `load`에서 `decoupledPayload`를 유지합니다.
+  - `enforcesEOF = false`는 커스텀 load 시절 EOF를 검사하지 않던 8종의 **현행
+    동작을 동결**하는 스위치입니다. 새 타입에서 끄지 마십시오 — 일괄 강제
+    전환은 실문서 확인과 함께 후속 이슈로 분리했습니다.
+
 ## 0.16.0 (2026-08-24)
 
 ### Breaking Changes

--- a/Sources/CoreHwp/AGENTS.md
+++ b/Sources/CoreHwp/AGENTS.md
@@ -31,12 +31,23 @@ CoreHwp/
    - `HwpFromDataWithVersion` — `Data` payload + `HwpVersion`
    - `HwpFromRecord` — child record가 있는 record
    - `HwpFromRecordWithVersion` — child record + version
+   - `HwpTagValidatedRecord`(`WithVersion`) — record tag 검증이 선행되는
+     record. `static let expectedTag`(`HwpSectionTag` 또는 `HwpDocInfoTag`)만
+     선언하면 default `load`가 tag 검증 + init + EOF 강제를 제공한다 (#83)
    - `HwpFromUInt` — bit packing된 `DWORD`/`UInt32` 속성 struct
 2. 기본은 `init(_ reader: inout DataReader, ...)`만 구현한다. `load(...)`는
    프로토콜의 default 구현이 제공하며 EOF를 강제한다.
-3. 예외: record tag 검증, stream 전체 record-tree 파싱, unknown/raw payload
-   보존처럼 default loader로 표현할 수 없는 경우에는 `load(...)`를 override할 수
-   있다. 새 예외를 추가하거나 기존 예외를 수정할 때는
+   - load 후 record 전체 payload를 `rawPayload`로 복원하는 tag-검증 모델은
+     `HwpRawPayloadRestoringRecord`를 함께 채택한다 — 복원 default가 보존
+     off(`.viewer`)에서 rawPayload를 비우므로, load 후 rawPayload를 다시 읽는
+     모델(`HwpListControl` 참조)에는 쓰지 말 것.
+   - `enforcesEOF`는 커스텀 load 시절 EOF를 검사하지 않던 기존 타입의 현행
+     동작 보존 스위치다 — 새 타입에서 끄지 말 것. 일괄 강제 전환은 후속
+     이슈로 분리한다 (#83).
+3. 예외: stream 전체 record-tree 파싱, unknown/raw payload 보존처럼 default
+   loader로 표현할 수 없는 경우에는 `load(...)`를 override할 수 있다
+   (단순 tag 검증은 예외가 아니다 — `HwpTagValidatedRecord`를 채택한다).
+   새 예외를 추가하거나 기존 예외를 수정할 때는
    `// MARK: loader contract exemption - <reason>` 주석으로 이유를 남기고,
    override 안에서 동일한 EOF/typed-error 보장을 직접 유지한다.
 4. 기본 모델 `init`은 해석한 byte만 소비한다. unknown payload, raw trailing,

--- a/Sources/CoreHwp/Models/DocInfo/CompatibleDocument/HwpCompatibleDocument.swift
+++ b/Sources/CoreHwp/Models/DocInfo/CompatibleDocument/HwpCompatibleDocument.swift
@@ -5,7 +5,9 @@ import Foundation
 
  Tag ID : HWPTAG_COMPATIBLE_DOCUMENT
  */
-public struct HwpCompatibleDocument: HwpFromRecord {
+public struct HwpCompatibleDocument: HwpTagValidatedRecord, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpDocInfoTag = .compatibleDocument
+
     /** 대상 프로그램 */
     public let targetDocument: UInt32
     /** 대상 프로그램 필드의 원문 payload */
@@ -46,18 +48,6 @@ public struct HwpCompatibleDocument: HwpFromRecord {
             .map(HwpTrackChange.load)
         rawPayload = targetPayload
         unknownChildren = Self.unconsumedRecords(from: children).map(HwpUnknownRecord.init)
-    }
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateDocInfoRecordTag(record, expectedTag: .compatibleDocument)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var compatibleDocument = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        compatibleDocument.rawPayload = record.options.preservedPayload(record.payload)
-        return compatibleDocument
     }
 }
 

--- a/Sources/CoreHwp/Models/DocInfo/CompatibleDocument/HwpLayoutCompatibility.swift
+++ b/Sources/CoreHwp/Models/DocInfo/CompatibleDocument/HwpLayoutCompatibility.swift
@@ -49,21 +49,11 @@ public struct HwpLayoutCompatibility: HwpFromData {
     }
 }
 
-extension HwpLayoutCompatibility: HwpFromRecord {
+extension HwpLayoutCompatibility: HwpTagValidatedRecord, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpDocInfoTag = .layoutCompatibility
+
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
         try self.init(&reader)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateDocInfoRecordTag(record, expectedTag: .layoutCompatibility)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var layoutCompatibility = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        layoutCompatibility.rawPayload = record.options.preservedPayload(record.payload)
-        return layoutCompatibility
     }
 }

--- a/Sources/CoreHwp/Models/DocInfo/HwpDocInfoRawRecords.swift
+++ b/Sources/CoreHwp/Models/DocInfo/HwpDocInfoRawRecords.swift
@@ -5,17 +5,13 @@ import Foundation
 
  Tag ID : HWPTAG_DOC_DATA
  */
-public struct HwpDocData: HwpFromRecord {
+public struct HwpDocData: HwpTagValidatedRecord {
+    static let expectedTag: HwpDocInfoTag = .docData
+
     public let rawPayload: Data
     public let docDataInfo: HwpDocDataInfo?
     public let forbiddenCharArray: [HwpForbiddenChar]
     public let unknownChildren: [HwpUnknownRecord]
-
-    // MARK: loader contract exemption - validates DocInfo tag before preserving raw payload
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try loadDocInfoRecord(record, expectedTag: .docData, as: Self.self)
-    }
 
     // MARK: loader contract exemption - DOC_DATA payload is retained for best-effort views
 
@@ -47,16 +43,12 @@ public struct HwpDocDataInfo: HwpPrimitive {
 
  Tag ID : HWPTAG_DISTRIBUTE_DOC_DATA
  */
-public struct HwpDistributeDocData: HwpFromRecord {
+public struct HwpDistributeDocData: HwpTagValidatedRecord {
+    static let expectedTag: HwpDocInfoTag = .distributeDocData
+
     public let rawPayload: Data
     public let distributeDocDataInfo: HwpDistributeDocDataInfo?
     public let unknownChildren: [HwpUnknownRecord]
-
-    // MARK: loader contract exemption - validates DocInfo tag before preserving raw payload
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try loadDocInfoRecord(record, expectedTag: .distributeDocData, as: Self.self)
-    }
 
     // MARK: loader contract exemption - DISTRIBUTE_DOC_DATA payload is retained as raw data
 
@@ -83,16 +75,12 @@ public struct HwpDistributeDocDataInfo: HwpPrimitive {
 
  Tag ID : HWPTAG_TRACK_CHANGE
  */
-public struct HwpTrackChange: HwpFromRecord {
+public struct HwpTrackChange: HwpTagValidatedRecord {
+    static let expectedTag: HwpDocInfoTag = .trackChange
+
     public let rawPayload: Data
     public let trackChangeInfo: HwpTrackChangeInfo?
     public let unknownChildren: [HwpUnknownRecord]
-
-    // MARK: loader contract exemption - validates DocInfo tag before preserving raw payload
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try loadDocInfoRecord(record, expectedTag: .trackChange, as: Self.self)
-    }
 
     // MARK: loader contract exemption - TRACK_CHANGE payload is retained for best-effort views
 
@@ -119,16 +107,12 @@ public struct HwpTrackChangeInfo: HwpPrimitive {
 
  Tag ID : HWPTAG_MEMO_SHAPE
  */
-public struct HwpMemoShape: HwpFromRecord {
+public struct HwpMemoShape: HwpTagValidatedRecord {
+    static let expectedTag: HwpDocInfoTag = .memoShape
+
     public let rawPayload: Data
     public let shapeInfo: HwpMemoShapeInfo?
     public let unknownChildren: [HwpUnknownRecord]
-
-    // MARK: loader contract exemption - validates DocInfo tag before preserving raw payload
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try loadDocInfoRecord(record, expectedTag: .memoShape, as: Self.self)
-    }
 
     // MARK: loader contract exemption - MEMO_SHAPE payload is retained for best-effort views
 
@@ -165,16 +149,12 @@ public struct HwpMemoShapeInfo: HwpPrimitive {
 
  Tag ID : HWPTAG_TRACK_CHANGE_CONTENT
  */
-public struct HwpTrackChangeContent: HwpFromRecord {
+public struct HwpTrackChangeContent: HwpTagValidatedRecord {
+    static let expectedTag: HwpDocInfoTag = .trackChangeContent
+
     public let rawPayload: Data
     public let contentInfo: HwpTrackChangeContentInfo?
     public let unknownChildren: [HwpUnknownRecord]
-
-    // MARK: loader contract exemption - validates DocInfo tag before preserving raw payload
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try loadDocInfoRecord(record, expectedTag: .trackChangeContent, as: Self.self)
-    }
 
     // MARK: loader contract exemption - TRACK_CHANGE_CONTENT payload is retained for views
 
@@ -214,16 +194,12 @@ public struct HwpTrackChangeTimestamp: HwpPrimitive {
 
  Tag ID : HWPTAG_TRACK_CHANGE_AUTHOR
  */
-public struct HwpTrackChangeAuthor: HwpFromRecord {
+public struct HwpTrackChangeAuthor: HwpTagValidatedRecord {
+    static let expectedTag: HwpDocInfoTag = .trackChangeAuthor
+
     public let rawPayload: Data
     public let authorInfo: HwpTrackChangeAuthorInfo?
     public let unknownChildren: [HwpUnknownRecord]
-
-    // MARK: loader contract exemption - validates DocInfo tag before preserving raw payload
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try loadDocInfoRecord(record, expectedTag: .trackChangeAuthor, as: Self.self)
-    }
 
     // MARK: loader contract exemption - TRACK_CHANGE_AUTHOR payload is retained for views
 
@@ -247,19 +223,18 @@ public struct HwpTrackChangeAuthorInfo: HwpPrimitive {
     public let rawTrailing: Data
 }
 
+/// `HwpTagValidatedRecord` 도입(#83)으로 프로덕션 호출부는 모두 프로토콜
+/// default `load`로 옮겨졌다 — 임의 `HwpFromRecord` 타입에 DocInfo tag 검증을
+/// 조합하는 이 진입점은 tag-검증 typed-error 계약 테스트가 사용한다.
+/// 검증 후에는 `T`의 `load` 의미론을 그대로 따르므로 tag-검증 채택 타입을
+/// 넘기면 타입 고유 `expectedTag`로 한 번 더 검증된다.
 func loadDocInfoRecord<T: HwpFromRecord>(
     _ record: HwpRecord,
     expectedTag: HwpDocInfoTag,
     as type: T.Type
 ) throws -> T {
     try validateDocInfoRecordTag(record, expectedTag: expectedTag)
-
-    var reader = DataReader(record.payload, options: record.options)
-    let model = try type.init(&reader, record.children)
-    if !reader.isEOF {
-        throw HwpError.bytesAreNotEOF(model: type, remain: reader.remainBytes)
-    }
-    return model
+    return try type.load(record)
 }
 
 func validateDocInfoRecordTag(

--- a/Sources/CoreHwp/Models/DocInfo/HwpIdMappings.swift
+++ b/Sources/CoreHwp/Models/DocInfo/HwpIdMappings.swift
@@ -63,17 +63,8 @@ public struct HwpIdMappings {
     public var unknownChildren: [HwpUnknownRecord]
 }
 
-extension HwpIdMappings: HwpFromRecordWithVersion {
-    static func load(_ record: HwpRecord, _ version: HwpVersion) throws -> Self {
-        try validateDocInfoRecordTag(record, expectedTag: .idMappings)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let idMappings = try self.init(&reader, record.children, version)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        return idMappings
-    }
+extension HwpIdMappings: HwpTagValidatedRecordWithVersion {
+    static let expectedTag: HwpDocInfoTag = .idMappings
 
     // swiftlint:disable:next function_body_length
     init() {

--- a/Sources/CoreHwp/Models/DocInfo/IdMappings/HwpForbiddenChar.swift
+++ b/Sources/CoreHwp/Models/DocInfo/IdMappings/HwpForbiddenChar.swift
@@ -29,12 +29,8 @@ extension HwpForbiddenChar: HwpFromData {
     }
 }
 
-extension HwpForbiddenChar: HwpFromRecord {
-    // MARK: loader contract exemption - validates DocInfo tag before preserving raw payload
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try loadDocInfoRecord(record, expectedTag: .forbiddenChar, as: Self.self)
-    }
+extension HwpForbiddenChar: HwpTagValidatedRecord {
+    static let expectedTag: HwpDocInfoTag = .forbiddenChar
 
     // MARK: loader contract exemption - forbidden-char record payload is opaque raw data
 

--- a/Sources/CoreHwp/Models/Section/AGENTS.md
+++ b/Sources/CoreHwp/Models/Section/AGENTS.md
@@ -113,8 +113,41 @@ Codable은 `rawPayload`/`charArray` 두 키만 인코딩하고 디코더가 재�
 달리 bytes 6-7이 셀 확장 속성이라 읽기 폭을 넓힐 수 없다는 근거가
 `HwpTable.swift` 주석). 되살리지 말 것.
 
+## tag 검증 load 채택 (#83)
+
+`HwpTagValidatedRecord` 계열 채택 41종 중 **31종이 이 폴더**다 (나머지 10종은
+DocInfo). 프로토콜 계약 자체는 `Utils/AGENTS.md`에 있고, 여기 남기는 것은 이
+폴더에서만 성립하는 세 가지다.
+
+- **`expectedTag`는 컨트롤을 식별하지 않는다.** 10종이 `.ctrlHeader` 하나를
+  공유하고(`HwpColumn`·`HwpFieldControl`·`HwpHyperlink`·`HwpGenShapeObject`·
+  `HwpPageNumberPosition`·`HwpOtherControl`·`HwpSectionDef`·`HwpShapeControl`·
+  `HwpTable`·`HwpCtrlHeader`), 실제 분기는 payload 선두 4-byte 컨트롤 ID다
+  (위 "컨트롤 Dispatch"). 새 컨트롤을 `expectedTag`로 가르려 하지 말 것 —
+  그 자리는 record tag이지 컨트롤 ID가 아니다.
+- **`enforcesEOF = false` 8곳이 전부 이 폴더다** (`HwpCtrlHeader`·`HwpCtrlData`·
+  `HwpFieldControl`·`HwpHyperlink`·`HwpGenShapeObject`·`HwpOtherControl`·
+  `HwpTable`·`HwpTableCellHeader`). 컨트롤 payload가 init이 통째로 소비하는
+  trailing으로 끝나기 때문이고, 커스텀 load 시절의 **현행 동작 동결**이지
+  설계가 아니다.
+- **version 유/무 양쪽을 채택하는 2종**(`HwpGenShapeObject`·`HwpShapeControl`)은
+  optional-version init에 다리를 놓는 비-optional `init(_:_:_ version:)`이
+  필요하다. `enforcesEOF` default가 `HwpTagValidatedRecordCore` 한 곳에만 있는
+  이유도 이 2종의 witness 모호성이다.
+
+`HwpShapeComponentRawRecordBacked`는 `HwpTagValidatedRecord where ExpectedTag ==
+HwpSectionTag`로 refine되어 자체 `expectedSectionTag`와 `load`를 버렸다 —
+raw-backed 세부 record 13종이 그 default를 공유한다.
+
+이 폴더에 남은 record `load` override는 둘뿐이고 둘 다 합성 load다:
+`HwpListControl.load`(헤더 load에 위임한 뒤 `decoupledPayload`로 덮어 뷰어
+모드에서도 표 141 재디코드용 byte를 남긴다)와 `HwpShapeComponent.load(_:_:)`
+(비-version load 재사용 + 글상자 후처리).
+
 ## 안티 패턴
 
+- 새 컨트롤 모델에서 `enforcesEOF = false` — 그 스위치는 #83 이전 8종의 현행
+  동작 동결이다 (위 "tag 검증 load 채택"). 새 타입은 default(`true`)를 쓴다.
 - 모르는 컨트롤에 대해 `invalidCtrlId`를 throw — `.unknown` 또는
   `.notImplemented`로 떨어뜨릴 것. throw 하면 미모델 컨트롤이 포함된 모든
   픽스처가 깨진다.

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/Column/HwpColumn.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/Column/HwpColumn.swift
@@ -81,24 +81,12 @@ extension HwpColumn: HwpFromData {
     }
 }
 
-extension HwpColumn: HwpFromRecord {
+extension HwpColumn: HwpTagValidatedRecord, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
         try self.init(&reader)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates column control tag before decoding
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var column = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        column.rawPayload = record.options.preservedPayload(record.payload)
-        return column
     }
 }
 

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/Field/HwpFieldControl.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/Field/HwpFieldControl.swift
@@ -153,7 +153,12 @@ public struct HwpMemoFieldParameter: HwpPrimitive {
     public let rawTrailing: Data
 }
 
-extension HwpFieldControl: HwpPrimitive {
+extension HwpFieldControl: HwpTagValidatedRecord, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+    /// 커스텀 load 시절 EOF를 검사하지 않던 현행 동작 보존 (#83) —
+    /// init이 trailing까지 전부 소비하므로 강제 전환은 후속 이슈에서 켠다.
+    static let enforcesEOF = false
+
     // MARK: loader contract exemption - preserves field rawTrailing for best-effort parameters
 
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
@@ -214,17 +219,6 @@ extension HwpFieldControl: HwpPrimitive {
         }
         rawPayload = try reader.consumedData(from: startOffset)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates field control tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var control = try self.init(&reader, record.children)
-        control.rawPayload = record.options.preservedPayload(record.payload)
-        return control
     }
 
     private static func fieldParameter(from data: Data) -> HwpFieldParameterParseResult? {

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/Field/HwpHyperlink.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/Field/HwpHyperlink.swift
@@ -61,7 +61,12 @@ public struct HwpHyperlink {
     }
 }
 
-extension HwpHyperlink: HwpPrimitive {
+extension HwpHyperlink: HwpTagValidatedRecord, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+    /// 커스텀 load 시절 EOF를 검사하지 않던 현행 동작 보존 (#83) —
+    /// init이 trailing까지 전부 소비하므로 강제 전환은 후속 이슈에서 켠다.
+    static let enforcesEOF = false
+
     // MARK: loader contract exemption - preserves hyperlink trailing payload
 
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
@@ -82,16 +87,5 @@ extension HwpHyperlink: HwpPrimitive {
         rawTrailing = reader.options.preservedPayload(try reader.readToEnd())
         rawPayload = try reader.consumedData(from: startOffset)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates hyperlink control tag before decoding
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var hyperlink = try self.init(&reader, record.children)
-        hyperlink.rawPayload = record.options.preservedPayload(record.payload)
-        return hyperlink
     }
 }

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/HwpCtrlData.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/HwpCtrlData.swift
@@ -15,15 +15,11 @@ public struct HwpCtrlData {
     }
 }
 
-extension HwpCtrlData: HwpFromRecord {
-    // MARK: loader contract exemption - validates CTRL_DATA tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlData)
-
-        var reader = DataReader(record.payload, options: record.options)
-        return try self.init(&reader, record.children)
-    }
+extension HwpCtrlData: HwpTagValidatedRecord {
+    static let expectedTag: HwpSectionTag = .ctrlData
+    /// 커스텀 load 시절 EOF를 검사하지 않던 현행 동작 보존 (#83) —
+    /// init이 payload를 전부 소비하므로 강제 전환은 후속 이슈에서 켠다.
+    static let enforcesEOF = false
 
     // MARK: loader contract exemption - CTRL_DATA payload is currently opaque raw data
 

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/HwpGenShapeObject.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/HwpGenShapeObject.swift
@@ -46,9 +46,20 @@ public struct HwpGenShapeObject {
     }
 }
 
-extension HwpGenShapeObject: HwpFromRecord {
+extension HwpGenShapeObject: HwpTagValidatedRecord, HwpTagValidatedRecordWithVersion,
+    HwpRawPayloadRestoringRecord
+{
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+    /// 커스텀 load 시절 EOF를 검사하지 않던 현행 동작 보존 (#83) —
+    /// init이 trailing까지 전부 소비하므로 강제 전환은 후속 이슈에서 켠다.
+    static let enforcesEOF = false
+
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
         try self.init(&reader, children, nil)
+    }
+
+    init(_ reader: inout DataReader, _ children: [HwpRecord], _ version: HwpVersion) throws {
+        try self.init(&reader, children, version as HwpVersion?)
     }
 
     // MARK: loader contract exemption - preserves common object trailing payload
@@ -82,29 +93,5 @@ extension HwpGenShapeObject: HwpFromRecord {
                     && $0.tagId != HwpSectionTag.ctrlData.rawValue
             }
             .map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates control-header tag before object decode
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        // The protocol default cannot validate the section record tag.
-        var reader = DataReader(record.payload, options: record.options)
-        var object = try self.init(&reader, record.children)
-        object.rawPayload = record.options.preservedPayload(record.payload)
-        return object
-    }
-
-    // MARK: loader contract exemption - validates control-header tag before versioned decode
-
-    static func load(_ record: HwpRecord, _ version: HwpVersion) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        // The protocol default cannot validate the section record tag.
-        var reader = DataReader(record.payload, options: record.options)
-        var object = try self.init(&reader, record.children, version)
-        object.rawPayload = record.options.preservedPayload(record.payload)
-        return object
     }
 }

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/HwpPageNumberPosition.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/HwpPageNumberPosition.swift
@@ -97,23 +97,11 @@ extension HwpPageNumberPosition: HwpFromData {
     }
 }
 
-extension HwpPageNumberPosition: HwpFromRecord {
+extension HwpPageNumberPosition: HwpTagValidatedRecord, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
         try self.init(&reader)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates control-header tag before decoding
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var pageNumberPosition = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        pageNumberPosition.rawPayload = record.options.preservedPayload(record.payload)
-        return pageNumberPosition
     }
 }

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/Other/HwpOtherControl.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/Other/HwpOtherControl.swift
@@ -234,7 +234,12 @@ extension HwpOtherControl {
     }
 }
 
-extension HwpOtherControl: HwpFromRecord {
+extension HwpOtherControl: HwpTagValidatedRecord, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+    /// 커스텀 load 시절 EOF를 검사하지 않던 현행 동작 보존 (#83) —
+    /// init이 trailing까지 전부 소비하므로 강제 전환은 후속 이슈에서 켠다.
+    static let enforcesEOF = false
+
     // MARK: loader contract exemption - preserves other-control trailing payload for typed views
 
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
@@ -259,17 +264,6 @@ extension HwpOtherControl: HwpFromRecord {
         unknownChildren = children
             .filter { $0.tagId != HwpSectionTag.ctrlData.rawValue }
             .map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates other control tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var control = try self.init(&reader, record.children)
-        control.rawPayload = record.options.preservedPayload(record.payload)
-        return control
     }
 }
 

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/SectionDef/HwpSectionDef.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/SectionDef/HwpSectionDef.swift
@@ -81,7 +81,9 @@ public struct HwpSectionDef {
     public var unknown: Data
 }
 
-extension HwpSectionDef: HwpFromRecordWithVersion {
+extension HwpSectionDef: HwpTagValidatedRecordWithVersion, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+
     init(_ reader: inout DataReader, _ children: [HwpRecord], _ version: HwpVersion) throws {
         let options = reader.options
         let startOffset = reader.byteOffset
@@ -132,20 +134,6 @@ extension HwpSectionDef: HwpFromRecordWithVersion {
 
         unknown = options.preservedPayload(try reader.readToEnd())
         rawPayload = try reader.consumedData(from: startOffset)
-    }
-
-    // MARK: loader contract exemption - validates section control tag before versioned decode
-
-    static func load(_ record: HwpRecord, _ version: HwpVersion) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var sectionDef = try self.init(&reader, record.children, version)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        sectionDef.rawPayload = record.options.preservedPayload(record.payload)
-        return sectionDef
     }
 }
 

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/Shape/HwpShapeComponent.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/Shape/HwpShapeComponent.swift
@@ -21,9 +21,9 @@ extension HwpShapeComponentRawRecord: HwpPrimitive {
     }
 }
 
-protocol HwpShapeComponentRawRecordBacked: HwpFromRecord {
-    static var expectedSectionTag: HwpSectionTag { get }
-
+protocol HwpShapeComponentRawRecordBacked: HwpTagValidatedRecord
+    where ExpectedTag == HwpSectionTag
+{
     init(rawPayload: Data, unknownChildren: [HwpUnknownRecord])
 }
 
@@ -38,19 +38,6 @@ extension HwpShapeComponentRawRecordBacked {
             unknownChildren: children.map(HwpUnknownRecord.init)
         )
     }
-
-    // MARK: loader contract exemption - validates shape record tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: expectedSectionTag)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let rawRecord = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        return rawRecord
-    }
 }
 
 /** 선 개체 요소 세부 record */
@@ -58,7 +45,7 @@ public struct HwpShapeComponentLine: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .shapeComponentLine
+    static let expectedTag: HwpSectionTag = .shapeComponentLine
 }
 
 /** 타원 개체 요소 세부 record */
@@ -66,7 +53,7 @@ public struct HwpShapeComponentEllipse: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .shapeComponentEllipse
+    static let expectedTag: HwpSectionTag = .shapeComponentEllipse
 }
 
 /** 호 개체 요소 세부 record */
@@ -74,7 +61,7 @@ public struct HwpShapeComponentArc: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .shapeComponentArc
+    static let expectedTag: HwpSectionTag = .shapeComponentArc
 }
 
 /** 다각형 개체 요소 세부 record */
@@ -82,7 +69,7 @@ public struct HwpShapeComponentPolygon: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .shapeComponentPolygon
+    static let expectedTag: HwpSectionTag = .shapeComponentPolygon
 }
 
 /** 곡선 개체 요소 세부 record */
@@ -90,7 +77,7 @@ public struct HwpShapeComponentCurve: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .shapeComponentCurve
+    static let expectedTag: HwpSectionTag = .shapeComponentCurve
 }
 
 /** 컨테이너 개체 요소 세부 record */
@@ -98,7 +85,7 @@ public struct HwpShapeComponentContainer: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .shapeComponentContainer
+    static let expectedTag: HwpSectionTag = .shapeComponentContainer
 }
 
 /** 차트 데이터 record */
@@ -106,7 +93,7 @@ public struct HwpShapeComponentChartData: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .chartData
+    static let expectedTag: HwpSectionTag = .chartData
 }
 
 /** 글맵시 개체 요소 세부 record */
@@ -114,7 +101,7 @@ public struct HwpShapeComponentTextart: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .shapeComponentTextart
+    static let expectedTag: HwpSectionTag = .shapeComponentTextart
 }
 
 /** 양식 개체 record */
@@ -122,7 +109,7 @@ public struct HwpShapeComponentFormObject: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .formObject
+    static let expectedTag: HwpSectionTag = .formObject
 }
 
 /** 메모 모양 record */
@@ -130,7 +117,7 @@ public struct HwpShapeComponentMemoShape: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .memoShape
+    static let expectedTag: HwpSectionTag = .memoShape
 }
 
 /** 메모 목록 record */
@@ -138,7 +125,7 @@ public struct HwpShapeComponentMemoList: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .memoList
+    static let expectedTag: HwpSectionTag = .memoList
 }
 
 /** 동영상 데이터 record */
@@ -146,7 +133,7 @@ public struct HwpShapeComponentVideoData: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .videoData
+    static let expectedTag: HwpSectionTag = .videoData
 }
 
 /** 아직 세부 타입이 확정되지 않은 개체 요소 세부 record */
@@ -154,7 +141,7 @@ public struct HwpShapeComponentUnknown: HwpShapeComponentRawRecordBacked {
     public var rawPayload: Data
     public var unknownChildren: [HwpUnknownRecord]
 
-    static let expectedSectionTag: HwpSectionTag = .shapeComponentUnknown
+    static let expectedTag: HwpSectionTag = .shapeComponentUnknown
 }
 
 /** 개체 요소 공통 레코드 */
@@ -286,7 +273,9 @@ extension HwpShapeComponent {
     }
 }
 
-extension HwpShapeComponent: HwpFromRecord {
+extension HwpShapeComponent: HwpTagValidatedRecord {
+    static let expectedTag: HwpSectionTag = .shapeComponent
+
     // MARK: loader contract exemption - preserves common shape-component payload as raw data
 
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
@@ -346,19 +335,6 @@ extension HwpShapeComponent: HwpFromRecord {
                     && !Self.consumedChildTagIds.contains(child.tagId)
             }
             .map { HwpUnknownRecord($0.element) }
-        return component
-    }
-
-    // MARK: loader contract exemption - validates shape-component tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .shapeComponent)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let component = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
         return component
     }
 
@@ -472,26 +448,15 @@ public struct HwpShapeComponentRectangle {
     public var unknownChildren: [HwpUnknownRecord]
 }
 
-extension HwpShapeComponentRectangle: HwpFromRecord {
+extension HwpShapeComponentRectangle: HwpTagValidatedRecord {
+    static let expectedTag: HwpSectionTag = .shapeComponentRectangle
+
     // MARK: loader contract exemption - rectangle component payload is raw-backed
 
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
         // rectangleDetail이 load 반환 후 rawPayload를 다시 읽으므로 분리 복사한다.
         rawPayload = reader.options.decoupledPayload(try reader.readToEnd())
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates rectangle component tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .shapeComponentRectangle)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let rectangle = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        return rectangle
     }
 }
 
@@ -512,7 +477,9 @@ public struct HwpShapeComponentOLE {
     public var unknownChildren: [HwpUnknownRecord]
 }
 
-extension HwpShapeComponentOLE: HwpFromRecord {
+extension HwpShapeComponentOLE: HwpTagValidatedRecord {
+    static let expectedTag: HwpSectionTag = .shapeComponentOle
+
     /** BinData id의 payload 내 offset (속성 UInt32 + extent INT32 × 2 = 12) */
     private static let binaryDataIdOffset = 12
 
@@ -524,19 +491,6 @@ extension HwpShapeComponentOLE: HwpFromRecord {
         binaryDataId = Self.binaryDataId(from: rawPayload)
         rawTrailing = Self.rawTrailing(from: rawPayload)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates OLE component tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .shapeComponentOle)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let ole = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        return ole
     }
 
     private static func binaryDataId(from payload: Data) -> UInt32? {
@@ -570,7 +524,9 @@ public struct HwpShapeComponentPicture {
     public var unknownChildren: [HwpUnknownRecord]
 }
 
-extension HwpShapeComponentPicture: HwpFromRecord {
+extension HwpShapeComponentPicture: HwpTagValidatedRecord {
+    static let expectedTag: HwpSectionTag = .shapeComponentPicture
+
     // MARK: loader contract exemption - picture component payload is best-effort raw-backed
 
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
@@ -579,19 +535,6 @@ extension HwpShapeComponentPicture: HwpFromRecord {
         binaryDataId = Self.binaryDataId(from: rawPayload)
         rawTrailing = Self.rawTrailing(from: rawPayload)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates picture component tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .shapeComponentPicture)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let picture = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        return picture
     }
 
     private static func binaryDataId(from payload: Data) -> UInt16? {

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/Shape/HwpShapeControl.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/Shape/HwpShapeControl.swift
@@ -64,9 +64,15 @@ public struct HwpShapeControl {
     }
 }
 
-extension HwpShapeControl: HwpFromRecord {
+extension HwpShapeControl: HwpTagValidatedRecord, HwpTagValidatedRecordWithVersion {
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
         try self.init(&reader, children, nil)
+    }
+
+    init(_ reader: inout DataReader, _ children: [HwpRecord], _ version: HwpVersion) throws {
+        try self.init(&reader, children, version as HwpVersion?)
     }
 
     // MARK: loader contract exemption - shape control preserves raw payload for fallback parsing
@@ -118,32 +124,6 @@ extension HwpShapeControl: HwpFromRecord {
                     && $0.tagId != HwpSectionTag.ctrlData.rawValue
             }
             .map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates shape control tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let shapeControl = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        return shapeControl
-    }
-
-    // MARK: loader contract exemption - validates shape control tag before versioned decode
-
-    static func load(_ record: HwpRecord, _ version: HwpVersion) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let shapeControl = try self.init(&reader, record.children, version)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        return shapeControl
     }
 
     private static func commonCtrlProperty(
@@ -217,7 +197,9 @@ public struct HwpEquationEdit {
     public var unknownChildren: [HwpUnknownRecord]
 }
 
-extension HwpEquationEdit: HwpFromRecord {
+extension HwpEquationEdit: HwpTagValidatedRecord {
+    static let expectedTag: HwpSectionTag = .eqEdit
+
     // MARK: loader contract exemption - equation edit payload is best-effort raw-backed
 
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
@@ -250,19 +232,6 @@ extension HwpEquationEdit: HwpFromRecord {
         fontNameRawPayload = opts.preservedPayload(payloadInfo.fontNameRawPayload)
         rawTrailing = opts.preservedPayload(payloadInfo.rawTrailing)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates equation edit tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .eqEdit)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let edit = try self.init(&reader, record.children)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
-        return edit
     }
 
     private static func payloadInfo(from payload: Data) -> HwpEquationEditPayloadInfo {

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/Table/HwpTable.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/Table/HwpTable.swift
@@ -34,7 +34,12 @@ public struct HwpTable {
     }
 }
 
-extension HwpTable: HwpFromRecordWithVersion {
+extension HwpTable: HwpTagValidatedRecordWithVersion, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+    /// 커스텀 load 시절 EOF를 검사하지 않던 현행 동작 보존 (#83) —
+    /// init이 trailing까지 전부 소비하므로 강제 전환은 후속 이슈에서 켠다.
+    static let enforcesEOF = false
+
     // MARK: loader contract exemption - preserves table control trailing payload
 
     init(_ reader: inout DataReader, _ children: [HwpRecord], _ version: HwpVersion) throws {
@@ -66,17 +71,6 @@ extension HwpTable: HwpFromRecordWithVersion {
         }
         cellArray = parsedChildren.cells
         unknownChildren = parsedChildren.unknownChildren
-    }
-
-    // MARK: loader contract exemption - validates table control tag before child parsing
-
-    static func load(_ record: HwpRecord, _ version: HwpVersion) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var table = try self.init(&reader, record.children, version)
-        table.rawPayload = record.options.preservedPayload(record.payload)
-        return table
     }
 
     private static func parseChildren(
@@ -183,7 +177,12 @@ extension HwpTableCellHeader {
     }
 }
 
-extension HwpTableCellHeader: HwpFromRecord {
+extension HwpTableCellHeader: HwpTagValidatedRecord, HwpRawPayloadRestoringRecord {
+    static let expectedTag: HwpSectionTag = .listHeader
+    /// 커스텀 load 시절 EOF를 검사하지 않던 현행 동작 보존 (#83) —
+    /// init이 trailing까지 전부 소비하므로 강제 전환은 후속 이슈에서 켠다.
+    static let enforcesEOF = false
+
     // MARK: loader contract exemption - preserves table-cell header trailing payload
 
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
@@ -199,16 +198,5 @@ extension HwpTableCellHeader: HwpFromRecord {
         cellProperty = HwpTableCellProperty.decode(from: trailing)
         rawPayload = try reader.consumedData(from: startOffset)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates LIST_HEADER tag before cell header decode
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .listHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        var header = try self.init(&reader, record.children)
-        header.rawPayload = record.options.preservedPayload(record.payload)
-        return header
     }
 }

--- a/Sources/CoreHwp/Models/Section/HwpCtrlHeader.swift
+++ b/Sources/CoreHwp/Models/Section/HwpCtrlHeader.swift
@@ -18,7 +18,12 @@ public struct HwpCtrlHeader {
     }
 }
 
-extension HwpCtrlHeader: HwpPrimitive {
+extension HwpCtrlHeader: HwpTagValidatedRecord {
+    static let expectedTag: HwpSectionTag = .ctrlHeader
+    /// 커스텀 load 시절 EOF를 검사하지 않던 현행 동작 보존 (#83) —
+    /// init이 payload를 전부 소비하므로 강제 전환은 후속 이슈에서 켠다.
+    static let enforcesEOF = false
+
     // MARK: loader contract exemption - malformed ctrl header still preserves raw payload
 
     init(_ reader: inout DataReader, _ children: [HwpRecord]) throws {
@@ -31,14 +36,5 @@ extension HwpCtrlHeader: HwpPrimitive {
         _ = try reader.readToEnd()
         rawPayload = try reader.consumedData(from: startOffset)
         unknownChildren = children.map(HwpUnknownRecord.init)
-    }
-
-    // MARK: loader contract exemption - validates control-header tag before raw preservation
-
-    static func load(_ record: HwpRecord) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .ctrlHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        return try self.init(&reader, record.children)
     }
 }

--- a/Sources/CoreHwp/Models/Section/HwpParagraph.swift
+++ b/Sources/CoreHwp/Models/Section/HwpParagraph.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-public struct HwpParagraph: HwpFromRecordWithVersion {
+public struct HwpParagraph: HwpTagValidatedRecordWithVersion {
+    static let expectedTag: HwpSectionTag = .paraHeader
+
     public var paraHeader: HwpParaHeader
 
     public var paraText: HwpParaText?
@@ -60,19 +62,6 @@ public struct HwpParagraph: HwpFromRecordWithVersion {
         paragraph.paraText = nil
         paragraph.unknownChildren = [HwpUnknownRecord(record)]
         paragraph.parseFailure = String(describing: error)
-        return paragraph
-    }
-
-    // MARK: loader contract exemption - validates paragraph record tag before decoding children
-
-    static func load(_ record: HwpRecord, _ version: HwpVersion) throws -> Self {
-        try validateSectionRecordTag(record, expectedTag: .paraHeader)
-
-        var reader = DataReader(record.payload, options: record.options)
-        let paragraph = try self.init(&reader, record.children, version)
-        if !reader.isEOF {
-            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
-        }
         return paragraph
     }
 

--- a/Sources/CoreHwp/Utils/AGENTS.md
+++ b/Sources/CoreHwp/Utils/AGENTS.md
@@ -12,7 +12,7 @@ Utils/
 ├── Type.swift            # DWORD / WORD / WCHAR typealias (HWP 스펙 이름)
 ├── ExcludeEquatable.swift # == 비교에서 특정 필드를 제외하는 property wrapper
 ├── Extensions/           # Data, Character, StringProtocol, BinaryInteger, Array, WCHAR
-├── Protocols/            # 5개 loader 프로토콜 + HwpPrimitive typealias
+├── Protocols/            # 5개 loader 프로토콜 + tag-검증 refinement + HwpPrimitive typealias
 └── Readers/              # StreamReader (OLE), HwpInflate (deflate), DataReader (byte), BitsReader (bit)
 ```
 
@@ -42,13 +42,27 @@ extension HwpFromX {
 EOF 체크는 load-bearing 규약이다 — 스펙 오독뿐 아니라 silent하게 truncate된
 payload도 잡아낸다.
 
-예외는 다음 경우에만 허용한다.
+record tag 검증이 default `load`보다 먼저 필요한 record는 override 대신
+`HwpTagValidatedRecord`/`HwpTagValidatedRecordWithVersion`을 채택한다 (#83) —
+`static let expectedTag`(`HwpSectionTag`/`HwpDocInfoTag` 양쪽 지원)만 선언하면
+default `load`가 tag 검증 + init + EOF 강제를 제공한다. 두 가지 변형 축이 있다.
 
-- record tag 검증이 default `load`보다 먼저 필요하다.
+- `HwpRawPayloadRestoringRecord` 채택: load 반환 직전 record 전체 payload를
+  `rawPayload`로 복원한다 (`preservedPayload` 게이트를 거치므로 보존
+  off에서는 비운다 — load 후 rawPayload를 다시 읽는 모델에는 쓰지 말 것).
+- `static let enforcesEOF = false`: 커스텀 load 시절 EOF를 검사하지 않던
+  기존 타입의 현행 동작 보존 스위치. 새 타입에서 끄지 말 것 — 기존 미검사
+  타입의 일괄 강제 전환은 실문서 fixture 확인과 함께 후속 이슈로 다룬다.
+
+`load` override 예외는 다음 경우에만 허용한다.
+
 - stream payload 전체를 `parseTreeRecord(data:)`에 넘겨야 한다.
 - unknown record/control 또는 아직 해석하지 않는 trailing bytes를
   `rawPayload`/`rawTrailing`/`unknown`으로 보존해야 한다.
 - public convenience loader가 OLE/FileWrapper 같은 다른 입력 형태를 다룬다.
+- tag-검증 default로 표현되지 않는 합성 load다 — 현재
+  `HwpListControl.load`(헤더 load에 위임 후 `decoupledPayload`로 덮음)와
+  `HwpShapeComponent.load(_:_:)`(비-version load 재사용 + 글상자 후처리)뿐.
 
 새 예외를 추가하거나 기존 예외를 수정할 때는
 `// MARK: loader contract exemption - <reason>` 주석을 `load` override 또는
@@ -63,6 +77,8 @@ consumes-all `init` 근처에 남긴다. override는 default loader와 동등하
 | `HwpFromDataWithVersion` | 평탄한 `Data` payload, `HwpVersion`에 따라 분기 |
 | `HwpFromRecord` | child record가 있는 record; `init(_:_ children:)` |
 | `HwpFromRecordWithVersion` | child record + version |
+| `HwpTagValidatedRecord` | `HwpFromRecord` + 선행 record tag 검증 (`expectedTag`) |
+| `HwpTagValidatedRecordWithVersion` | `HwpFromRecordWithVersion` + 선행 tag 검증 |
 | `HwpFromUInt` | bit packing된 속성을 `DWORD`/`UInt32`에서 디코딩 |
 
 ## Reader
@@ -172,8 +188,10 @@ dispatch.
   Apple 빌드와의 대칭이 깨진다.
 - reader/record tree 경계 검증에 `precondition`, force unwrap, `fatalError`를
   사용 — malformed HWP 입력은 모두 typed `HwpError`로 반환해야 한다.
-- 여섯 번째 loader 프로토콜 추가 — (Data|Record) × (Version|noVersion) + UInt의
-  matrix로 이미 충분하다. 기존 것을 확장할 것.
+- 새 입력 형태의 loader 프로토콜 추가 — (Data|Record) × (Version|noVersion) +
+  UInt의 matrix로 이미 충분하다. Record 갈래의 tag-검증 refinement
+  (`HwpTagValidatedRecord` 계열, #83)까지가 허용 범위이고, 그 밖은 기존 것을
+  확장할 것.
 - 프로토콜 `init`에서 이유 없이 모든 byte를 소진하지 않거나, 반대로
   `readToEnd()`로 잔여 byte를 숨긴다. 기본 모델은 해석한 byte만 소비하고 default
   loader가 EOF를 검증하게 둔다. raw 보존/record-tree 파싱 예외는 위 계약에 맞춰

--- a/Sources/CoreHwp/Utils/Protocols/HwpTagValidatedRecord.swift
+++ b/Sources/CoreHwp/Utils/Protocols/HwpTagValidatedRecord.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// record tag 검증을 default `load`에 통합하기 위한 tag 추상화.
+/// tag 체계가 Section/DocInfo 두 갈래이므로 검증 진입점만 프로토콜로 연다 —
+/// error 문구는 기존 validate 함수를 그대로 사용해 두 갈래의 기존 진단
+/// 메시지를 바꾸지 않는다 (#83).
+protocol HwpValidatableRecordTag {
+    static func validateRecordTag(_ record: HwpRecord, expectedTag: Self) throws
+}
+
+extension HwpSectionTag: HwpValidatableRecordTag {
+    static func validateRecordTag(_ record: HwpRecord, expectedTag: Self) throws {
+        try validateSectionRecordTag(record, expectedTag: expectedTag)
+    }
+}
+
+extension HwpDocInfoTag: HwpValidatableRecordTag {
+    static func validateRecordTag(_ record: HwpRecord, expectedTag: Self) throws {
+        try validateDocInfoRecordTag(record, expectedTag: expectedTag)
+    }
+}
+
+/// 두 tag-검증 프로토콜(version 유/무)이 공유하는 요구사항.
+/// version 유무 양쪽을 채택하는 타입에서 `enforcesEOF` default가
+/// witness 모호성을 내지 않도록 default를 이 한 곳에만 둔다.
+protocol HwpTagValidatedRecordCore {
+    associatedtype ExpectedTag: HwpValidatableRecordTag
+    static var expectedTag: ExpectedTag { get }
+    /// EOF 강제 여부. 기본 true. 커스텀 load 시절 EOF를 검사하지 않던
+    /// 타입의 현행 동작을 그대로 옮기는 스위치다 — 일괄 강제 전환은
+    /// 실문서에서 새 `bytesAreNotEOF`를 낼 수 있어 후속 이슈로 분리한다.
+    /// 새 타입에서 끄지 말 것 (#83).
+    static var enforcesEOF: Bool { get }
+}
+
+extension HwpTagValidatedRecordCore {
+    static var enforcesEOF: Bool {
+        true
+    }
+}
+
+/**
+ record tag 검증이 선행되는 record 모델.
+
+ 채택 측은 `expectedTag`와 `init(_:_:)`만 작성한다 — default `load`가
+ tag 검증 + reader 생성(options 전파) + init + EOF 강제를 제공하므로
+ `load`를 override하지 않는다 (`HwpFromRecord` 계약과 동일).
+ */
+protocol HwpTagValidatedRecord: HwpFromRecord, HwpTagValidatedRecordCore {}
+
+extension HwpTagValidatedRecord {
+    static func load(_ record: HwpRecord) throws -> Self {
+        try loadTagValidated(record)
+    }
+
+    /// tag 검증 load 코어 — rawPayload 복원 변형이 재사용한다.
+    static func loadTagValidated(_ record: HwpRecord) throws -> Self {
+        try ExpectedTag.validateRecordTag(record, expectedTag: expectedTag)
+
+        var reader = DataReader(record.payload, options: record.options)
+        let model = try self.init(&reader, record.children)
+        if enforcesEOF, !reader.isEOF {
+            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
+        }
+        return model
+    }
+}
+
+/** record tag 검증이 선행되는 record 모델의 version 변형. */
+protocol HwpTagValidatedRecordWithVersion: HwpFromRecordWithVersion, HwpTagValidatedRecordCore {}
+
+extension HwpTagValidatedRecordWithVersion {
+    static func load(_ record: HwpRecord, _ version: HwpVersion) throws -> Self {
+        try loadTagValidated(record, version)
+    }
+
+    /// tag 검증 load 코어 — rawPayload 복원 변형이 재사용한다.
+    static func loadTagValidated(_ record: HwpRecord, _ version: HwpVersion) throws -> Self {
+        try ExpectedTag.validateRecordTag(record, expectedTag: expectedTag)
+
+        var reader = DataReader(record.payload, options: record.options)
+        let model = try self.init(&reader, record.children, version)
+        if enforcesEOF, !reader.isEOF {
+            throw HwpError.bytesAreNotEOF(model: Self.self, remain: reader.remainBytes)
+        }
+        return model
+    }
+}
+
+/**
+ load 반환 직전 record payload 전체를 `rawPayload`로 복원하는 변형 표식.
+
+ 커스텀 load마다 반복되던
+ `model.rawPayload = record.options.preservedPayload(record.payload)` 한 줄을
+ default로 옮긴다 (#83). init이 채운 rawPayload를 record 전체 payload로
+ 덮으므로 보존 off(`.viewer`)에서는 비워져 메모리 이득이 유지된다 —
+ load 후 rawPayload를 다시 읽는 타입은 이 표식 대신 커스텀 load에서
+ `decoupledPayload`를 유지해야 한다 (`HwpListControl` 참조).
+ */
+protocol HwpRawPayloadRestoringRecord {
+    var rawPayload: Data { get set }
+}
+
+extension HwpTagValidatedRecord where Self: HwpRawPayloadRestoringRecord {
+    static func load(_ record: HwpRecord) throws -> Self {
+        var model = try loadTagValidated(record)
+        model.rawPayload = record.options.preservedPayload(record.payload)
+        return model
+    }
+}
+
+extension HwpTagValidatedRecordWithVersion where Self: HwpRawPayloadRestoringRecord {
+    static func load(_ record: HwpRecord, _ version: HwpVersion) throws -> Self {
+        var model = try loadTagValidated(record, version)
+        model.rawPayload = record.options.preservedPayload(record.payload)
+        return model
+    }
+}

--- a/Tests/CoreHwpTests/AGENTS.md
+++ b/Tests/CoreHwpTests/AGENTS.md
@@ -233,6 +233,23 @@ payload가 0xFFF 이상이면 size 비트가 level 필드로 넘쳐 헤더가 �
   비거나 경로가 어긋나 **아무것도 비교하지 않은 채 초록**이 되는 것을 막는다.
   픽스처는 늘어나는 방향으로만 움직이므로 내려서 통과시키지 말 것.
 
+## tag 검증 load 스위트 (#83)
+
+`DocInfo/RawRecords/DocInfoRawRecordTagValidationTests.swift`가
+**`loadDocInfoRecord`의 유일한 소비자**다 — 프로덕션 호출부는 전부 프로토콜
+default `load`로 옮겨졌다. 프로덕션 미참조라고 지우지 말 것: 임의
+`HwpFromRecord` 타입에 DocInfo tag 검증을 조합했을 때의 typed-error 계약은 그
+진입점에서만 검사할 수 있다 (채택 타입은 자기 `expectedTag`가 이미 박혀 있다).
+
+- **그 헬퍼에 tag-검증 채택 타입을 넘기면 두 번 검증된다** (헬퍼 인자 tag +
+  타입 고유 `expectedTag`). 그래서 이 파일의 tag 불일치 단언은 헬퍼가 아니라
+  모델의 `load`를 직접 부른다 — 감싸면 어느 쪽 검증이 던졌는지 구별되지 않는다.
+- **`enforcesEOF` default(`true`)를 잠그는 것은 `Models/Layout/`의 두 파일이다** —
+  `CompatibleDocumentStabilityTests`·`LayoutCompatibilityStabilityTests`가
+  tag-검증 모델의 `load`에서 `bytesAreNotEOF`를 단언하므로 default가 뒤집히면
+  여기서 빨개진다. `Stability/Core/LoaderProtocolStabilityTests.swift`는 base
+  프로토콜 5종의 EOF만 보므로 이 갈래를 대신 증명하지 않는다.
+
 ## 테스트 스타일
 
 | 패턴 | 예시 | 언제 |


### PR DESCRIPTION
record tag 검증 보일러플레이트를 로더 프로토콜의 기본 구현으로 통합했다. 채택
타입에는 `static let expectedTag`와 `init`만 남고, 기본 `load`가 tag 검증, reader
생성(options 전파), init 호출, EOF 강제를 수행한다.

## 도입한 프로토콜(5종, 모두 `internal`)

| 프로토콜 | 역할 |
|---|---|
| `HwpValidatableRecordTag` | `HwpSectionTag`와 `HwpDocInfoTag` 검증의 공통 진입점. 기존 `validate…RecordTag` 함수를 그대로 호출하므로 **진단 메시지는 바뀌지 않는다** |
| `HwpTagValidatedRecordCore` | `expectedTag`와 `enforcesEOF`를 공통으로 요구한다. version 유무 양쪽 프로토콜을 모두 채택하는 타입에서 `enforcesEOF`의 기본 구현이 모호해지지 않도록 이 프로토콜에만 구현한다 |
| `HwpTagValidatedRecord` | `HwpFromRecord`용 선행 tag 검증 |
| `HwpTagValidatedRecordWithVersion` | `HwpFromRecordWithVersion`용 선행 tag 검증 |
| `HwpRawPayloadRestoringRecord` | `load`가 반환되기 직전에 record 전체 payload를 `rawPayload`로 복원하는 변형을 표시한다 |

채택 타입은 총 41종이다: Section tag 31종, DocInfo tag 10종.

## 이슈 제안과 달리 구현한 두 지점

**① `loadDocInfoRecord`를 흡수하지 않고 테스트 전용으로 유지했다.** 이슈에서는 tag
타입을 두 프로토콜로 나눌 경우 이 전역 함수를 DocInfo 쪽 기본 구현에
흡수하자고 제안했다. 구현에서는 `associatedtype`을 택해 프로토콜을 나누지
않았으므로 흡수할 DocInfo 전용 기본 구현 자체가 없어졌다. 그러나 함수는 삭제하지
않았다. 임의의 `HwpFromRecord` 타입에 DocInfo tag 검증을 **조합**했을 때의
typed-error 계약은 프로토콜 채택 타입으로 재현할 수 없기 때문이다(채택 타입에는
자체 `expectedTag`가 이미 지정되어 검증이 중복된다). 프로덕션 호출부 7곳은 모두
프로토콜의 기본 구현으로 옮겼고, 현재 이 함수는
`DocInfoRawRecordTagValidationTests`에서만 사용한다. 프로덕션에서 참조하지
않더라도 삭제하지 말아야 하는 이유와 이중 검증 위험을 소스의 doc-comment와
`Tests/CoreHwpTests/AGENTS.md`에 적어 두었다.

**② `restoresRawPayload` 정적 플래그와 mutating 훅 대신
`HwpRawPayloadRestoringRecord` 프로토콜과 제약 확장을 사용했다.** 이 프로토콜을
함께 채택하면 더 구체적인 제약 확장(`where Self: …`)의 `load`가 선택되므로
런타임 분기가 없다. 복원 과정은
`record.options.preservedPayload(...)`를 그대로 거쳐 `.viewer` 프리셋의 메모리
이득도 유지된다.

## 남긴 예외

이번 리팩터와 관련된 커스텀 `load`는 두 개를 남겼으며, 둘 다 tag 검증 기본
구현만으로 표현할 수 없는 **조합형 `load`**다.

- `HwpListControl.load(_:_:)` — 헤더 load에 위임한 뒤 헤더 `rawPayload`를
  `decoupledPayload`로 덮는다. `load` 이후 해당 payload를 표 141에 따라 다시
  디코딩할 때 사용하므로 보존을 끈 상태에서도 비워져서는 안 된다. 따라서
  `HwpRawPayloadRestoringRecord`를 쓸 수 없다.
  (이슈에서 처음부터 흡수 대상에서 제외한 1곳)
- `HwpShapeComponent.load(_:_:)` — version 없는 `load`를 재사용한 뒤 글상자
  후처리를 한다. 자체 tag 검증이 없어 이슈가 집계한 커스텀 구현 24곳에도 포함되지
  않았다.

`enforcesEOF = false`인 8종(`HwpCtrlHeader`·`HwpCtrlData`·`HwpFieldControl`·
`HwpHyperlink`·`HwpGenShapeObject`·`HwpOtherControl`·`HwpTable`·
`HwpTableCellHeader`)은 이슈가 지정한 2단계 전환에 따라 **기존 동작을 그대로
유지**하기 위한 예외이며, 새 설계 원칙이 아니다. 현재 각 타입의 init은 payload를
끝까지 소비하므로 이 검사가 결과를 바꾸지는 않지만, 기존 커스텀 `load`의 계약을
보존하려고 `false`로 두었다. EOF 강제로의 전환은 실제 문서 검증과 함께 별도
이슈에서 진행한다. 새 타입에서 이 스위치를 끄지 말라고 루트와 Section의
`AGENTS.md` 안티 패턴에 적었다.

## 지표

이슈의 “세는 명령을 함께 적어 집계 범위를 고정할 것”이라는 요구에 따라 명령도
함께 싣는다. `.swift` 필터 기준, `main`(`d68b47f`) → HEAD(`6a6e160`).

```sh
git grep -n "loader contract exemption" <rev> -- Sources/CoreHwp | grep "\.swift:" | wc -l
git grep -n "static func load"          <rev> -- Sources/CoreHwp | grep "\.swift:" | wc -l
git grep -n "validateSectionRecordTag(record" <rev> -- Sources/CoreHwp | grep "\.swift:" | wc -l
```

| 지표 | main | HEAD | 델타 |
|---|---:|---:|---:|
| `// MARK: loader contract exemption` 주석 | 77 | 49 | **−28** |
| `static func load` | 83 | 58 | **−25** (31개 제거, 6개 신설) |
| `validateSectionRecordTag(record` 호출부 | 22 | 2 | **−20** |

남은 호출부 두 곳은 `HwpListControl`(위 예외)과 프로토콜 기본 구현의 전달 지점이다.

`Sources/**/*.swift` 기준 19개 파일 `+255 / −381`: 신설 프로토콜 파일 118줄을
추가하고도 **순 126줄 감소**했다.

## 공개 API 영향

**없다.** 신설 프로토콜 5종은 모두 `internal`이고, `expectedTag`와
`enforcesEOF`도 `internal static`이다. 공개 타입의 시그니처, 동작, Codable 형상은
모두 그대로이므로 `api-breaking`이 아닌 `maintenance`이며 버전은 patch로
산정된다.

## 검증

로컬(macOS, Apple Silicon):

| 게이트 | 결과 |
|---|---|
| `swift build` | `Build complete!` (경고 2건은 HwpKitCore의 기존 경고로, 이 브랜치와 무관) |
| `swift test` | **exit 0** — 2,305개 실행 / **0 실패** / 49 skip |
| ↳ CoreHwpTests | 1,284개 / 0 실패 |
| ↳ HwpKitCoreTests | 627개 / 0 실패 |
| ↳ HwpKitNativeTests | 246개 / 0 실패 |
| ↳ HwpKitTests | 148개 / 0 실패 (49 skip) |
| `swiftformat --lint` (변경된 19개 파일) | `0/19 files require formatting` |
| `swiftlint` | error 0건 |

skip 49건은 모두 opt-in 게이트에 해당하는 스위트다. 47건은 육안 대조용 덤프
스위트(`FixturePreviewDumpScratch`, `HWP_ALLPAGES` 게이트)이고, 2건은 기준선이
머신에 종속된 `FixtureRenderHashSnapshotTests`와
`FixturePreviewFidelityTests`(`HWP_SNAPSHOT_TESTS` 게이트)다.

**커밋된 기준선 또는 예산을 사용하는 4종은 skip되지 않고 실제로 실행되어
통과했다.**
`FixtureBlockLayoutSnapshotTests`(19.7s), `FixtureRenderGoldenTests`(0.8s),
`FixtureFootnoteOverlapTests`(19.7s), `testPageCountsMatchManifest`가 모두 실패 없이
통과했다. 따라서 조판 좌표, 잉크 그리드, 페이지 수, 각주 겹침 예산을 검사하는
상시 렌더 회귀 게이트에서는 변화가 검출되지 않았다.

로컬에서 실행하지 않은 항목: Linux(zlib 경로), iOS 시뮬레이터, 커버리지 하드
게이트. 세 항목 모두 CI가 판정한다.

## 커밋

리팩터 1개, 문서 3개, CHANGELOG 1개로 나눴다(문서 커밋을 분리하는 #80과
#72/#73의 전례를 따랐다).

- `f6dfd84` refactor(parser): tag 검증 load 보일러플레이트를 HwpTagValidatedRecord로 흡수한다
- `1f7be21` docs(parser): loader 프로토콜 계약에 tag 검증 refinement를 더한다
- `bd1781f` docs(parser): Section 문서에 tag 검증 채택 계약을 적는다
- `c3e7fa2` docs(test): tag 검증 load 스위트 계약을 CoreHwpTests 문서에 적는다
- `6a6e160` docs(release): tag 검증 프로토콜 리팩터를 CHANGELOG에 기록한다

Closes #83
