### PR TITLE
fix(rendering): pgnp 네 번째 WCHAR에 따른 쪽 번호 줄표 처리

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@
   (`project.yml`의 `dev.sboh.hwpx` 선언, `DropOpenSupport.swift`,
   `ContentView.swift`).
 
+### Changed
+
+- **쪽 번호 줄표는 문서가 지정한 경우에만 그립니다** (#138). 쪽 번호 위치
+  컨트롤(`pgnp`)의 4번째 WCHAR(`HwpPageNumberPosition.unused`)가 줄표 문자를
+  실을 때만 "- 1 -"처럼 양옆에 붙이고, 0이면 "1"만 그립니다. 종전에는 앞/뒤
+  장식 문자가 없으면 무조건 줄표를 붙여, 줄표를 넣지 않은 문서가 한글.app과
+  다르게 보였습니다. 공개 문서(표 147)가 '항상 "-"'라 적은 이 필드는 실물에서
+  줄표 문자(0x2D) 또는 0으로 갈립니다.
+
 ## 0.17.0 (2026-08-28)
 
 ### Added

--- a/Sources/CoreHwp/Models/Section/CtrlHeader/HwpPageNumberPosition.swift
+++ b/Sources/CoreHwp/Models/Section/CtrlHeader/HwpPageNumberPosition.swift
@@ -16,7 +16,13 @@ public struct HwpPageNumberPosition {
     public var headDecoration: WCHAR
     /** 뒤 장식 문자 */
     public var tailDecoration: WCHAR
-    /** 항상 "-" */
+    /**
+     줄표 문자. 앞/뒤 장식 문자가 없을 때 쪽 번호 양옆에 붙는다 ("- 1 -").
+
+     공개 문서(표 147)는 '항상 "-"'라 적지만, 실물은 줄표를 넣은 문서에서 0x2D('-'),
+     넣지 않은 문서에서 0이다 (#138). 한글.app이 재저장한 HWPX의 `hp:pageNum`
+     `sideChar`에 대응한다. 필드 이름은 호환을 위해 유지한다.
+     */
     public var unused: WCHAR
     /** unknown */
     public var unknown: UInt32

--- a/Sources/HwpKitCore/AGENTS.md
+++ b/Sources/HwpKitCore/AGENTS.md
@@ -48,7 +48,8 @@ CoreHwp.HwpFile
         └─ per page (cacheCurrentPage)
             활성 머리말/꼬리말 밴드 반복 방출 (짝/홀 우선, pageHide 0x01/0x02 억제,
               자동 쪽 번호 (atno kind 0) 밴드는 논리 쪽 번호 치환 + 캐시 제외)
-            쪽 번호 방출 (표 147/148 위치·모양·장식, pageHide 0x20 억제)
+            쪽 번호 방출 (표 147/148 위치·모양·장식, 장식 없으면 줄표 필드(4번째
+              WCHAR `unused`)가 0이 아닐 때만 "- N -", pageHide 0x20 억제 — #138)
             HwpFootnoteLayout.place  # 각주 하단 배치, 넘침은 다음 페이지 이월
             HwpPaintListBuilder → HwpPaintList
         └─ 문서/구역 끝: HwpFootnoteLayout.placeFlow  # 미주 (표 134 bits 8-9)

--- a/Sources/HwpKitCore/Layout/Paginator/HwpPageChromeBuilder.swift
+++ b/Sources/HwpKitCore/Layout/Paginator/HwpPageChromeBuilder.swift
@@ -292,10 +292,14 @@ struct HwpPageChromeBuilder {
             decorationHead: position.headDecoration,
             decorationTail: position.tailDecoration
         )
-        // 장식 문자가 없으면 한글 기본 줄표 "- N -" (표 147의 '항상 -' 필드,
-        // 한글.app 실측: 장식 0인 헌법주석도 "- xi -"로 표시)
-        if position.headDecoration == 0, position.tailDecoration == 0 {
-            text = "- \(text) -"
+        // 앞/뒤 장식 문자가 없으면 줄표 필드(표 147 4번째 WCHAR)를 따른다. 공개
+        // 문서는 '항상 -'라 적지만 실물은 줄표 문자 또는 0이다 — 헌법주석은 0x2D라
+        // 한글.app 실측 "- xi -"처럼 감싸고, noori는 0이라 "1"만 그린다 (#138).
+        if position.headDecoration == 0, position.tailDecoration == 0,
+           position.unused != 0, let scalar = Unicode.Scalar(position.unused)
+        {
+            let sideChar = String(Character(scalar))
+            text = "\(sideChar) \(text) \(sideChar)"
         }
         let attributed = pageNumberAttributedString(text: text, alignment: placement.alignment)
         return AnyHwpBlock(

--- a/Tests/CoreHwpTests/Fixtures/README.md
+++ b/Tests/CoreHwpTests/Fixtures/README.md
@@ -590,7 +590,7 @@ Tests/CoreHwpTests/Fixtures/<fixture-id>/
 | text box | 검증 중: 한컴오피스 생성 가로 글상자의 `genShapeObject`, `rectangle` shape component, 내부 list/paragraph text, 미해석 rectangle detail raw payload 보존 기준 | `text-box` |
 | header/footer | 검증 중: 한컴오피스 생성 문서의 header/footer control count와 nested text 기준 | `header-footer` |
 | footnote/endnote | 검증 중: 한컴오피스 생성 문서의 footnote/endnote control count와 nested text 기준 | `footnote-endnote` |
-| page number | 검증 중: `pgnp` control의 property, 장식 문자 필드, raw payload 기준 | `noori` |
+| page number | 검증 중: `pgnp` control의 property, 앞/뒤 장식 문자·줄표 필드(4번째 WCHAR, `unused`), raw payload 기준. 줄표 필드가 0인 `noori`는 쪽 번호를 한글.app과 같이 "1"로 렌더한다 (#138) | `noori` |
 | large/legacy document | 검증 중: 41개 section, 14,000개 이상 nested paragraph, 7,000개 이상 control을 가진 HWP 5.0.2.2 문서 기준. 대표 fixture truncation/corruption 테스트에도 포함해 typed `HwpError` 반환을 확인 | `legacy-common-control-property` |
 | other known controls | 검증 중: `atno`, `nwno`, `pghd`, `idxm`, `tdut` raw payload/trailing bytes/unknown child records 기준. `pghd`는 raw bit field, `idxm`은 UTF-16LE 문자열 typed value까지 검증 | `legacy-common-control-property` |
 | columns | 검증 중: 다단 control과 DocInfo/document properties 기준 | `Column`, `noori` |

--- a/Tests/HwpKitCoreTests/HwpPaginatorPageNumberTests.swift
+++ b/Tests/HwpKitCoreTests/HwpPaginatorPageNumberTests.swift
@@ -48,6 +48,45 @@ import XCTest
             expect(self.pageNumberTexts(of: secondPage)).to(contain("-ii-"))
         }
 
+        func testPageNumberWithoutSideCharDrawsBareNumber() async throws {
+            // 줄표 필드(표 147 4번째 WCHAR)가 0이면 번호만 — noori 실측, 한글.app "1" (#138)
+            let paginator = try makePaginator(
+                firstParagraphControls: [
+                    .section(HwpSynthetic.sectionDef(pageHeight: 30000)),
+                    HwpSynthetic.pageNumberPositionControl(
+                        numberFormat: 0,
+                        displayPosition: 5,
+                        sideChar: nil
+                    ),
+                ]
+            )
+
+            let firstPage = try await paginator.page(at: 0)
+            let secondPage = try await paginator.page(at: 1)
+
+            expect(self.pageNumberTexts(of: firstPage)) == ["1"]
+            expect(self.pageNumberTexts(of: secondPage)) == ["2"]
+        }
+
+        func testPageNumberDecorationsTakePrecedenceOverSideChar() async throws {
+            // 앞/뒤 장식 문자가 있으면 줄표 필드 값과 무관하게 장식만 붙는다
+            let paginator = try makePaginator(
+                firstParagraphControls: [
+                    .section(HwpSynthetic.sectionDef(pageHeight: 30000)),
+                    HwpSynthetic.pageNumberPositionControl(
+                        numberFormat: 0,
+                        displayPosition: 5,
+                        headDecoration: "[",
+                        tailDecoration: "]",
+                        sideChar: "-"
+                    ),
+                ]
+            )
+
+            let firstPage = try await paginator.page(at: 0)
+            expect(self.pageNumberTexts(of: firstPage)) == ["[1]"]
+        }
+
         func testPageHideSuppressesPageNumberOnControlPage() async throws {
             // 첫 문단의 pghd (0x20)는 1페이지 쪽 번호만 감춘다 (헌법주석 표지 구조)
             let paginator = try makePaginator(

--- a/Tests/HwpKitCoreTests/HwpSyntheticNumberingFixtures.swift
+++ b/Tests/HwpKitCoreTests/HwpSyntheticNumberingFixtures.swift
@@ -69,11 +69,14 @@ extension HwpSynthetic {
     /// 쪽 번호 위치 (pgNumPos, 표 147/148) 컨트롤.
     /// displayPosition: 0 없음, 1~3 위 (좌/중/우), 4~6 아래 (좌/중/우),
     /// 7/8 바깥쪽, 9/10 안쪽. numberFormat: 표 134 번호 모양.
+    /// sideChar: 줄표 필드(표 147 4번째 WCHAR, `unused`) — 한글 기본값 "-",
+    /// nil이면 0 (줄표 없음, noori 실측).
     static func pageNumberPositionControl(
         numberFormat: Int = 0,
         displayPosition: Int = 5,
         headDecoration: Character? = nil,
-        tailDecoration: Character? = nil
+        tailDecoration: Character? = nil,
+        sideChar: Character? = "-"
     ) -> CoreHwp.HwpCtrlId {
         var property = CoreHwp.HwpPageNumberPositionProperty()
         property.numberFormat = numberFormat
@@ -87,7 +90,7 @@ extension HwpSynthetic {
             userSymbol: 0,
             headDecoration: headDecoration?.utf16.first ?? 0,
             tailDecoration: tailDecoration?.utf16.first ?? 0,
-            unused: 0x2D,
+            unused: sideChar?.utf16.first ?? 0,
             unknown: 0,
             rawPayload: Data(),
             rawTrailing: Data(),

--- a/Tests/HwpKitTests/BlockSnapshots/noori.json
+++ b/Tests/HwpKitTests/BlockSnapshots/noori.json
@@ -177,8 +177,8 @@
           "kind" : "text",
           "payload" : "none",
           "role" : "pageChrome",
-          "textLength" : 5,
-          "textPrefix" : "- 1 -"
+          "textLength" : 1,
+          "textPrefix" : "1"
         }
       ],
       "page" : 0
@@ -348,8 +348,8 @@
           "kind" : "text",
           "payload" : "none",
           "role" : "pageChrome",
-          "textLength" : 5,
-          "textPrefix" : "- 2 -"
+          "textLength" : 1,
+          "textPrefix" : "2"
         }
       ],
       "page" : 1
@@ -419,8 +419,8 @@
           "kind" : "text",
           "payload" : "none",
           "role" : "pageChrome",
-          "textLength" : 5,
-          "textPrefix" : "- 3 -"
+          "textLength" : 1,
+          "textPrefix" : "3"
         }
       ],
       "page" : 2

--- a/Tests/HwpKitTests/FixtureObjectRenderTests.swift
+++ b/Tests/HwpKitTests/FixtureObjectRenderTests.swift
@@ -69,6 +69,23 @@ final class FixtureObjectRenderTests: XCTestCase {
         expect(image.frame.minY) < host.frame.maxY
     }
 
+    func testNooriPageNumbersHaveNoSideChar() async throws {
+        // pgnp 줄표 필드(표 147 4번째 WCHAR)가 0인 문서 — 한글.app은 "1"만 그린다 (#138).
+        // 쪽 크롬 블록은 쪽 번호뿐이라 페이지별 문자열이 그대로 쪽 번호다. 쪽수
+        // 자체는 결정론 resolver 스위트(testPageCountsMatchManifest·블록 스냅샷)가
+        // 핀하므로 여기서는 기본 resolver 아래 "번호만"이라는 성질만 본다.
+        // 매니페스트 visibleTextContains는 부분 문자열 검사라 본문 숫자와 섞여
+        // "1"·"2"·"3" 핀이 무의미하다 — 그래서 쪽 크롬 블록 등식으로 잠근다.
+        let document = try await loadFixture("noori")
+        let pageNumbers = document.pages.map { page in
+            page.blocks
+                .filter { $0.role == .pageChrome && $0.kind == .text }
+                .compactMap { $0.attributedString?.string }
+        }
+        expect(pageNumbers.count) >= 2
+        expect(pageNumbers) == document.pages.indices.map { ["\($0 + 1)"] }
+    }
+
     // MARK: - BinData (그림 3장)
 
     func testBinDataRendersThreeDistinctImageReferences() async throws {


### PR DESCRIPTION
Closes #138

줄표를 넣지 않은 문서의 쪽 번호가 `- 1 -`로 표시되던 문제를 한글.app과 동일하게 `1`로 표시하도록 수정합니다. 줄표는 문서에 지정된 경우에만 표시합니다.

## 요약

한글.app 12.30.0에서 `noori`를 열면 페이지 하단의 쪽 번호가 `1`이지만, 기존 hwp-swift 렌더러는 `- 1 -`로 표시했습니다(2·3쪽도 동일). 이 PR을 적용하면 `noori` 세 쪽의 쪽 번호 블록 문자열은 각각 `1`, `2`, `3`이 됩니다. 헌법주석(1,030쪽)의 `- 239 -`처럼 줄표가 지정된 쪽 번호는 그대로 유지됩니다.

## 원인

쪽 번호 위치 컨트롤(`pgnp`, 표 147)은 속성 다음에 WCHAR 네 개(사용자 기호, 앞 장식 문자, 뒤 장식 문자, 공개 문서에 '항상 "-"'로 설명된 문자)를 저장합니다. 모델은 네 번째 WCHAR를 `HwpPageNumberPosition.unused`로 파싱하지만 렌더링에는 사용하지 않았습니다. `HwpPageChromeBuilder.pageNumberBlock`은 앞/뒤 장식 문자가 0이면 이 값과 관계없이 항상 `- N -` 형태로 감쌌습니다. 이 기본 동작은 헌법주석 실측(`fffbc81`, 한글.app 목차 `- xi -`)을 기준으로 도입됐습니다.

실제 HWP 페이로드에서 네 번째 WCHAR 값은 문서마다 다릅니다.

| 픽스처 | pgnp | 앞/뒤 장식 | 네 번째 WCHAR | 한글.app |
|---|---|---|---|---|
| `legacy-common-control-property`(헌법주석) | 3건 | 0 / 0 | `0x2D` (`-`) | `- xi -` |
| `noori` | 1건 | 0 / 0 | `0` | `1` |

한글.app에서 다시 저장한 HWPX에는 같은 컨트롤이 `<hp:pageNum pos="BOTTOM_CENTER" formatType="DIGIT" sideChar=""/>`로 기록됩니다. 따라서 헌법주석의 줄표는 렌더러의 기본값이 아니라 문서가 네 번째 WCHAR에 저장한 값이며, 공개 문서의 '항상 "-"' 설명은 실제 파일과 다릅니다.

## 변경 사항

- `HwpPageChromeBuilder.pageNumberBlock`: 앞/뒤 장식 문자가 없으면 네 번째 WCHAR가 0이 아니고 유효한 문자인 경우 해당 문자로 쪽 번호 양옆을 감싸며, 0이면 번호만 표시합니다. 앞/뒤 장식 문자가 있으면 기존처럼 장식 문자가 우선합니다(`-i-` 테스트 유지).
- `HwpPageNumberPosition.unused`: 문서화 주석을 실제 의미(줄표 문자, 0이면 없음)에 맞게 수정했습니다. 필드 이름과 매니페스트 키 `unused`는 유지하므로 공개 API 시그니처는 바뀌지 않습니다.
- 테스트
  - `HwpSynthetic.pageNumberPositionControl`에 `sideChar` 매개변수(기본값 `-`)를 추가했습니다. 기존 `- N -` 테스트는 유지하고, `sideChar`가 `nil`일 때 `1`, 앞/뒤 장식 문자가 있을 때 `[1]`을 표시하는 테스트를 추가했습니다.
  - `FixtureObjectRenderTests.testNooriPageNumbersHaveNoSideChar`에서 `noori`의 쪽 번호 블록 문자열을 페이지별로 정확히 비교합니다. 이슈에서 제안한 매니페스트 `visibleTextContains` 검사는 부분 문자열 방식이라 본문의 `1`, `2`, `3`과 구분할 수 없으므로 이 테스트로 대체했습니다. 쪽수 3은 결정적 글꼴 리졸버를 사용하는 `testPageCountsMatchManifest`와 블록 스냅샷이 검증합니다.
  - `BlockSnapshots/noori.json`: 쪽 번호 블록 세 항목만 `- N -`(문자 수 5)에서 `N`(문자 수 1)으로 재생성했습니다. 좌표는 바뀌지 않았고 다른 픽스처의 스냅샷도 바뀌지 않았습니다.
- 문서: `CHANGELOG.md`의 Unreleased `Changed`, `Tests/CoreHwpTests/Fixtures/README.md`의 page number 행, `Sources/HwpKitCore/AGENTS.md`의 파이프라인 도식을 갱신했습니다.

## 검증

- `swift test`: 1,469개 테스트, 실패 0건(블록 스냅샷 재생성 후 통과, 렌더 골든은 재기록 없이 통과).
- 한컴 번들 폰트를 사용하지 않는 기본 모드의 noori PrvImage 정합성 검사(opt-in `FixturePreviewFidelityTests`): MAE 0.0164(임계값 0.041).
- 렌더 이미지: `HWP_ALLPAGES=noori`로 다시 렌더한 1·2·3쪽 하단에서 쪽 번호가 각각 `1`, `2`, `3`으로 표시됩니다. 한글.app과의 대조는 #138에 첨부된 2026-09-02 스크린샷을 기준으로 했습니다.

<img width="1800" height="230" alt="noori 1·2·3쪽 하단의 줄표 없는 쪽 번호" src="https://github.com/user-attachments/assets/d403ea90-a116-408b-a3fd-aafcb87f0e8b" />

## 후속 작업

#135의 HWPX `hp:pageNum` 매핑에서는 `sideChar`에 대응하는 값을 이 네 번째 WCHAR에 매핑해야 합니다. #135의 HWPX 렌더 가드(`1`, `2`, `3`)는 이 PR 이후 성립합니다.
