### PR TITLE
feat(hwpx): HWPX 쪽 번호 위치(hp:pageNum) 매핑 및 쪽 번호 렌더 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,9 +344,10 @@ walker로 받는다)로 잰다 — 오버레이 개체는 블록을 키우지 �
 CI ✓인 다섯 스위트가 도는 근거는 전부 `HwpFontResolver.testDeterministic`
 하나다 — 폰트 조회 세 축(시스템 등록 폰트·한컴 번들·문서 대체 글꼴)을 모두
 닫아 설치 폰트와 무관하게 같은 CTFont가 나온다. `HwpxFixtureRenderTests`도
-쪽수 두 축(manifest 대조·HWP 쌍 대조)에서 그 resolver를 쓰고, 같은 클래스의
-가시 텍스트 축만 기본 resolver다 — 좌표가 아니라 문자열 포함만 보므로 폰트의
-함수가 아니다 (HWP 쪽 `testAllFixturesRenderExpectedText`와 같은 기준).
+쪽수 두 축(manifest 대조·HWP 쌍 대조)과 쪽 크롬 텍스트 축(HWP 쌍 대조, #135)에서
+그 resolver를 쓰고, 같은 클래스의 가시 텍스트 축만 기본 resolver다 — 좌표가
+아니라 문자열 포함만 보므로 폰트의 함수가 아니다 (HWP 쪽
+`testAllFixturesRenderExpectedText`와 같은 기준).
 **이 스위트들의 로더를 기본 resolver로 되돌리면 안 된다**: 좌표가 설치 폰트
 메트릭의 함수가 되어 한컴오피스가 없는 CI 러너와 갈리고, 굴림·바탕·함초롬체가
 설치된 한국인 기여자 머신에서만 빨개진다. **넷째 축은 대체 폰트다** — 세 축을 닫아 모든 face를 Menlo로

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   `(fromWrapper:)`가 파일 선두 바이트로 HWP(OLE)/HWPX(ZIP)를 자동 감지해
   같은 문서 모델로 변환하므로, 뷰어(`HwpKit`)는 코드 변경 없이 `.hwpx`를
   렌더합니다. 1차 지원 범위는 본문 텍스트·글자/문단 모양·스타일·구역/쪽
-  설정·단·표·그림이며, 조판 캐시(`<hp:linesegarray>`)를 매핑해 한글.app과
-  같은 쪽나눔을 유지합니다. 범위 밖 요소는 `HwpFile.parseDiagnostics()`에
+  설정·단·표·그림·쪽 번호 위치(#135)이며, 조판 캐시(`<hp:linesegarray>`)를
+  매핑해 한글.app과 같은 쪽나눔을 유지합니다. 범위 밖 요소는 `HwpFile.parseDiagnostics()`에
   보고하고 건너뜁니다. ZIP 컨테이너는 외부 의존성 없이 읽으며, 잘못된
   아카이브·XML은 새 `HwpError` 케이스(`invalidArchive`·
   `archiveEntryDoesNotExist`·`archiveEntrySizeLimitExceeded`·`invalidXML`)로

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ CoreHwp는 현재 읽기 전용 binary HWP reader에 초점을 둡니다. 파싱
 HWPX(OWPML, `.hwpx`)도 읽습니다 — 같은 `HwpFile` 진입점이 파일 선두 바이트로
 HWP(OLE)/HWPX(ZIP)를 자동 감지해 동일한 문서 모델로 변환하므로, 뷰어 타깃은
 두 포맷을 구분 없이 렌더합니다. 1차 지원 범위는 본문 텍스트·글자/문단 모양·
-스타일·구역/쪽 설정·단·표·그림이고, 그 밖의 요소는 진단
+스타일·구역/쪽 설정·단·표·그림·쪽 번호 위치이고, 그 밖의 요소는 진단
 (`HwpFile.parseDiagnostics()`)에 남기고 건너뜁니다.
 
 자세한 reader 지원 범위는 [Sources/CoreHwp/AGENTS.md](Sources/CoreHwp/AGENTS.md),

--- a/Sources/CoreHwp/AGENTS.md
+++ b/Sources/CoreHwp/AGENTS.md
@@ -160,8 +160,8 @@ HWPX(OWPML, `.hwpx`)는 **변환 파싱**으로 읽습니다 — `HwpFile`의 pu
 3종이 파일 선두 바이트로 OLE/ZIP을 자동 감지해, ZIP이면 `Sources/CoreHwp/Hwpx/`
 파이프라인이 OWPML XML을 같은 `Hwp*` 모델로 합성합니다 (별도 모델·별도 public
 타입 없음, 상세 규약은 `Hwpx/AGENTS.md`). 1차 범위는 본문 텍스트·글자/문단
-모양·스타일·구역/쪽 설정·단·표·그림이고, 그 밖의 요소(각주·머리말 내용·도형·
-수식·번호 매기기 등)는 실제 4CC를 실은 `.notImplemented`와 합성 tagId(0)의
+모양·스타일·구역/쪽 설정·단·표·그림·쪽 번호 위치이고, 그 밖의 요소(각주·머리말
+내용·도형·수식·번호 매기기 등)는 실제 4CC를 실은 `.notImplemented`와 합성 tagId(0)의
 `unknownRecords`로 강등되어 `parseDiagnostics()`에 보고됩니다. 같은 문서의
 HWP↔HWPX 파싱 등가는 `Tests/CoreHwpTests/FixtureHarness/Hwpx/`의
 `HwpxHwpEquivalenceTests`가 실물 변환 쌍 10종으로 고정합니다.

--- a/Sources/CoreHwp/Hwpx/AGENTS.md
+++ b/Sources/CoreHwp/Hwpx/AGENTS.md
@@ -81,8 +81,15 @@ HWPX `<hh:strikeout>`)을 .hwp는 글자 아래 단선으로, .hwpx는 글자 �
 `HwpxNumberFormatMapper` — `hh:paraHead numFormat`·`hp:autoNumFormat type`도
 같은 NumberType1 열거라 승격 시 재사용), `sideChar` → 4번째 WCHAR `unused`
 (줄표 문자, #138 — 빈 문자열 0, 두 글자 이상은 첫 UTF-16 unit). 앞/뒤 장식
-문자·사용자 기호는 HWPX에 대응 속성이 없어 0. 조판(`HwpPageChromeBuilder`)은
-typed 필드만 읽으므로 표 147 16바이트 payload 합성은 진단·매니페스트 등식용이다.
+문자·사용자 기호는 HWPX에 대응 속성이 없어 0. 생략 속성은 OWPML ParaList
+스키마의 `default`(`pos` TOP_LEFT·`formatType` DIGIT·`sideChar` "-")를 따르고
+미지 이름은 0으로 접는다(위치를 추측해 그리지 않는다) — 한글.app 실저장본은
+세 속성을 항상 명시해 생략 경로의 실물은 없다. 조판(`HwpPageChromeBuilder`)은
+typed 필드만 읽으므로 표 147 16바이트 payload 합성은 `.default`에서 바이너리
+pgnp와 같은 모양을 유지하는 보존용이고, `.viewer`에서는 `preservedPayload`
+게이트로 비운다(바이너리 `consumedData`와 패리티 — HWPX 매니페스트에 payload
+핀은 없고 등가 투영도 rawPayload를 제외한다). 강등 컨트롤(`degradedControl`)의
+요소명 payload는 게이트 없이 남는 선행 편차라 별도 후속이다.
 실측 근거는 둘이다. (1) noori 쌍 — `BOTTOM_CENTER`↔5·`DIGIT`↔0·`sideChar=""`↔0,
 HWP 쌍 manifest `pageNumberPositions[0]`과 payload 바이트 동일. (2) 2026-09-02
 한글.app 12.30.0의 쪽 번호 매기기 대화상자로 만든 .hwp/.hwpx 쌍 4종 —
@@ -118,3 +125,6 @@ HWP 쌍 manifest `pageNumberPositions[0]`과 payload 바이트 동일. (2) 2026-
   .hwpx로 저장한 뒤, .hwp는 `HwpFile`로 열어 `pgnp`(`HwpPageNumberPosition`의
   `property`·`userSymbol`·`unused`)를, .hwpx는 `Contents/section0.xml`의
   `hp:pageNum` 속성을 읽어 대조한다 (2026-09-02 실측 4쌍이 이 절차다).
+- `<hp:pageNum/>`(속성 생략)을 한글.app이 실제로 왼쪽 위 "- N -"으로 그리는지
+  — 우리는 스키마 `default`대로 TOP_LEFT(1)·"-"(0x2D)로 읽지만, 실저장본은
+  항상 세 속성을 명시해 실물이 없다(제3자 저장기 문서를 확보하면 대조할 것).

--- a/Sources/CoreHwp/Hwpx/AGENTS.md
+++ b/Sources/CoreHwp/Hwpx/AGENTS.md
@@ -59,19 +59,43 @@ numbering/bullet(배열 비움 — 번호·글머리표 문자가 렌더에서 �
 제목 블록의 선행 "-"가 HWP 렌더에만 보이는 것이 실측 사례다. 파스 텍스트
 등가에는 영향 없음), 각주/미주·머리말/꼬리말
 내용(`.notImplemented`), 도형(line/rect/…)·OLE·수식·차트·글상자
-(`.notImplemented`), 쪽 번호 위치(`pgnp` — noori 꼬리 쪽 번호가 HWPX 렌더에서
-빠진다, 2026-09-02 한글.app 대조 실측), 형광펜·변경 추적 표식(zero-width
+(`.notImplemented`), 자동 번호·새 번호·홀/짝수 조정(`atno`·`nwno`·`pgct` —
+HWPX 픽스처 10종에 사례 없음), 형광펜·변경 추적 표식(zero-width
 진단), 그러데이션/이미지 채우기, 명시 탭 정지, 쪽 테두리. 승격 시 대응
 요소를 `HwpxControlMapper` 분류표에서 옮긴다.
 
 2026-09-02 한글.app 12.30.0 나란히 육안 대조(변환 쌍 10종 13쪽, 한컴 폰트
 모드): 쪽수 10종 전부 일치, 표·그림·다단·글자 장식·쪽나눔 일치. HWPX
-렌더에만 보이는 격차는 위 범위 밖 3건(글머리표 "-" #133·차트 OLE #134·쪽 번호
-#135)뿐이고, HWP 쌍 렌더와 HWPX 렌더는 그 3건을 빼면 동일했다. 한글.app
-자체가 포맷에 따라
+렌더에만 보이던 격차는 범위 밖 3건(글머리표 "-" #133·차트 OLE #134·쪽 번호
+#135)이었고, HWP 쌍 렌더와 HWPX 렌더는 그 3건을 빼면 동일했다. 쪽 번호는
+#135에서 승격돼 남은 격차는 2건이다. 한글.app 자체가 포맷에 따라
 다르게 그리는 것이 하나 있다 — CharShape 취소선 견본(HWP 밑줄 종류 raw 2 ↔
 HWPX `<hh:strikeout>`)을 .hwp는 글자 아래 단선으로, .hwpx는 글자 가운데
 취소선으로 그린다. 우리는 두 포맷 모두 HWP 쪽(아래 단선)으로 그린다 (#136).
+
+## 쪽 번호 위치 (`hp:pageNum` → `pgnp`, #135)
+
+`HwpxPageNumberMapper`가 `.pageNumberPosition(HwpPageNumberPosition)`으로
+승격한다 — 구역 부속 컨트롤(코드 21) 중 유일한 typed 매핑이다. `pos` →
+`displayPosition`(표 148 bit 8-11), `formatType` → `numberFormat`(표 134,
+`HwpxNumberFormatMapper` — `hh:paraHead numFormat`·`hp:autoNumFormat type`도
+같은 NumberType1 열거라 승격 시 재사용), `sideChar` → 4번째 WCHAR `unused`
+(줄표 문자, #138 — 빈 문자열 0, 두 글자 이상은 첫 UTF-16 unit). 앞/뒤 장식
+문자·사용자 기호는 HWPX에 대응 속성이 없어 0. 조판(`HwpPageChromeBuilder`)은
+typed 필드만 읽으므로 표 147 16바이트 payload 합성은 진단·매니페스트 등식용이다.
+실측 근거는 둘이다. (1) noori 쌍 — `BOTTOM_CENTER`↔5·`DIGIT`↔0·`sideChar=""`↔0,
+HWP 쌍 manifest `pageNumberPositions[0]`과 payload 바이트 동일. (2) 2026-09-02
+한글.app 12.30.0의 쪽 번호 매기기 대화상자로 만든 .hwp/.hwpx 쌍 4종 —
+`OUTSIDE_TOP`+`ROMAN_CAPITAL`+줄표 ↔ property 0x0702·4번째 WCHAR 0x2D,
+`INSIDE_BOTTOM`+`DECAGON_CIRCLE_HANJA`+줄표 없음 ↔ 0x0A10·0,
+`BOTTOM_LEFT`+`HANGUL_SYLLABLE`+줄표 ↔ 0x0408·0x2D,
+`TOP_CENTER`+`CIRCLED_DIGIT`+줄표 ↔ 0x0201·0x2D. 즉 `pos` 5값·`formatType`
+5값이 표 148·표 134 코드와 일치하고, "줄표 넣기"는 앞/뒤 장식 WCHAR가 아니라
+4번째 WCHAR에만 실리며 HWPX는 `sideChar="-"`/`""`로 쓴다. 네 쌍 모두 payload
+16바이트(미해석 UINT32 없음)였다. 가드는
+`HwpxPageNumberMapperTests`(대응표·payload·실측 쌍)·`HwpxHwpEquivalenceTests`
+(pageNumberPositions 축)·`HwpxFixtureRenderTests.testHwpxPageChromeMatchesHwpPairs`
+(noori 각 쪽 "1"·"2"·"3")다.
 
 ## 실파일 검증 대기 항목
 
@@ -80,3 +104,17 @@ HWPX `<hh:strikeout>`)을 .hwp는 글자 아래 단선으로, .hwpx는 글자 �
 - `hp:pagePr landscape` 값 의미 (실측: 세로 A4가 `WIDELY`) — 조판은
   width/height만 쓰므로 property로 옮기지 않았다.
 - textWrap 6값 전체 목록·`hp:t` 내 비앵커 요소 목록·배포용 HWPX의 표식.
+- `hp:pageNum` 열거 대응표의 미실측 값 — `pos` 11값 중 실측은 5값(위 "쪽 번호
+  위치")이고 미실측은 `TOP_LEFT`·`TOP_RIGHT`·`BOTTOM_RIGHT`·`OUTSIDE_BOTTOM`·
+  `INSIDE_TOP`과 `NONE`(0 — 쪽 번호 없는 문서는 `hp:pageNum` 자체를 쓰지 않아
+  실물이 없다). `formatType` 19값 중 실측은 5값, 미실측은 대화상자가 제공하는
+  9종 중 `ROMAN_SMALL`·`LATIN_CAPITAL`·`IDEOGRAPH`·`DECAGON_CIRCLE`과 대화상자에
+  없는 10종(`LATIN_SMALL`·`CIRCLED_LATIN_CAPITAL`·`CIRCLED_LATIN_SMALL`·
+  `CIRCLED_HANGUL_SYLLABLE`·`CIRCLED_HANGUL_JAMO`·`CIRCLED_IDEOGRAPH`·
+  `HANGUL_JAMO`·`HANGUL_PHONETIC`·`SYMBOL`·`USER_CHAR`). 실측된 값이 모두
+  스키마 나열 순서 = 표 코드였으므로 나머지도 같은 규칙으로 채웠다.
+  `USER_CHAR`의 문자(표 147 사용자 기호 WCHAR)를 HWPX가 어느 속성에 쓰는지는
+  미확정 — 확정하려면 한글.app 쪽 번호 매기기 대화상자로 만든 문서를 .hwp와
+  .hwpx로 저장한 뒤, .hwp는 `HwpFile`로 열어 `pgnp`(`HwpPageNumberPosition`의
+  `property`·`userSymbol`·`unused`)를, .hwpx는 `Contents/section0.xml`의
+  `hp:pageNum` 속성을 읽어 대조한다 (2026-09-02 실측 4쌍이 이 절차다).

--- a/Sources/CoreHwp/Hwpx/Owpml/HwpxControlMapper.swift
+++ b/Sources/CoreHwp/Hwpx/Owpml/HwpxControlMapper.swift
@@ -57,6 +57,11 @@ enum HwpxControlMapper {
             )
         case "fieldEnd":
             return .inlineOnly(code: 4, fourCC: HwpFieldCtrlId.unknown.rawValue)
+        case "pageNum":
+            // 쪽 번호 위치(표 147/148) — 구역 부속 컨트롤(코드 21) 중 유일한
+            // typed 승격. 조판이 `.pageNumberPosition`만 등록하므로 강등 상태로는
+            // 쪽 번호가 그려지지 않는다 (#135).
+            return HwpxPageNumberMapper.anchor(node, maxDepth: context.unknownDepthLimit)
         case "tbl":
             return .anchor(
                 code: 11,
@@ -134,7 +139,8 @@ enum HwpxControlMapper {
         "video": HwpCommonCtrlId.genShapeObject.rawValue,
     ]
 
-    /// 개체가 아닌 구역 부속 컨트롤 — (제어 문자 코드, 4CC).
+    /// 개체가 아닌 구역 부속 컨트롤 중 미구현 강등 대상 — (제어 문자 코드, 4CC).
+    /// 같은 코드 21의 `pageNum`은 위에서 typed 매핑으로 승격됐다.
     static let sectionAttachments: [String: (code: UInt16, fourCC: UInt32)] = [
         "header": (16, HwpOtherCtrlId.header.rawValue),
         "footer": (16, HwpOtherCtrlId.footer.rawValue),
@@ -142,7 +148,6 @@ enum HwpxControlMapper {
         "endNote": (17, HwpOtherCtrlId.endnote.rawValue),
         "autoNum": (18, HwpOtherCtrlId.autoNumber.rawValue),
         "newNum": (18, HwpOtherCtrlId.newNumber.rawValue),
-        "pageNum": (21, HwpOtherCtrlId.pageNumberPosition.rawValue),
         "pageNumCtrl": (21, HwpOtherCtrlId.pageCT.rawValue),
         "pageHiding": (21, HwpOtherCtrlId.pageHide.rawValue),
         "bookmark": (22, HwpOtherCtrlId.bookmark.rawValue),

--- a/Sources/CoreHwp/Hwpx/Owpml/HwpxControlMapper.swift
+++ b/Sources/CoreHwp/Hwpx/Owpml/HwpxControlMapper.swift
@@ -61,7 +61,7 @@ enum HwpxControlMapper {
             // 쪽 번호 위치(표 147/148) — 구역 부속 컨트롤(코드 21) 중 유일한
             // typed 승격. 조판이 `.pageNumberPosition`만 등록하므로 강등 상태로는
             // 쪽 번호가 그려지지 않는다 (#135).
-            return HwpxPageNumberMapper.anchor(node, maxDepth: context.unknownDepthLimit)
+            return HwpxPageNumberMapper.anchor(node, context: context)
         case "tbl":
             return .anchor(
                 code: 11,

--- a/Sources/CoreHwp/Hwpx/Owpml/HwpxNumberFormatMapper.swift
+++ b/Sources/CoreHwp/Hwpx/Owpml/HwpxNumberFormatMapper.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// OWPML `NumberType1`(번호 모양 이름) → HWP 5.0 표 134 번호 모양 코드.
+///
+/// 쪽 번호 위치(`hp:pageNum formatType`)·각주/미주 번호 모양
+/// (`hp:autoNumFormat type`)·번호 문단 머리(`hh:paraHead numFormat`)가 같은
+/// 열거를 쓴다. 코드는 `HwpNumberFormat`(HwpKitCore)이 소비하는 표 134 값이며,
+/// 이름 순서가 표 134 코드 순서와 같다. 실측: `DIGIT`↔0(noori 쌍),
+/// `CIRCLED_DIGIT`↔1·`ROMAN_CAPITAL`↔2·`HANGUL_SYLLABLE`↔8·
+/// `DECAGON_CIRCLE_HANJA`↔16(2026-09-02 한글.app 12.30.0 .hwp/.hwpx 쌍) —
+/// 나머지는 같은 규칙(KS X 6101 스키마 나열 순서)으로 채웠다
+/// (`Sources/CoreHwp/Hwpx/AGENTS.md` "실파일 검증 대기 항목").
+enum HwpxNumberFormatMapper {
+    static let codes: [String: Int] = [
+        "DIGIT": 0, // 1, 2, 3
+        "CIRCLED_DIGIT": 1, // ①, ②, ③
+        "ROMAN_CAPITAL": 2, // I, II, III
+        "ROMAN_SMALL": 3, // i, ii, iii
+        "LATIN_CAPITAL": 4, // A, B, C
+        "LATIN_SMALL": 5, // a, b, c
+        "CIRCLED_LATIN_CAPITAL": 6, // Ⓐ, Ⓑ, Ⓒ
+        "CIRCLED_LATIN_SMALL": 7, // ⓐ, ⓑ, ⓒ
+        "HANGUL_SYLLABLE": 8, // 가, 나, 다
+        "CIRCLED_HANGUL_SYLLABLE": 9, // ㉮, ㉯, ㉰
+        "HANGUL_JAMO": 10, // ㄱ, ㄴ, ㄷ
+        "CIRCLED_HANGUL_JAMO": 11, // ㉠, ㉡, ㉢
+        "HANGUL_PHONETIC": 12, // 일, 이, 삼
+        "IDEOGRAPH": 13, // 一, 二, 三
+        "CIRCLED_IDEOGRAPH": 14, // ㊀, ㊁, ㊂
+        "DECAGON_CIRCLE": 15, // 갑, 을, 병
+        "DECAGON_CIRCLE_HANJA": 16, // 甲, 乙, 丙
+        "SYMBOL": 0x80, // 4가지 문자 반복
+        "USER_CHAR": 0x81, // 사용자 지정 문자
+    ]
+
+    /// 누락·미지 이름은 0(숫자)으로 폴백한다 — 뷰어(`HwpNumberFormat`)도 범위
+    /// 밖 코드를 아라비아 숫자로 그리므로 두 폴백이 같은 결과를 낸다.
+    static func code(for name: String?) -> Int {
+        codes[name ?? "DIGIT"] ?? 0
+    }
+}

--- a/Sources/CoreHwp/Hwpx/Owpml/HwpxPageNumberMapper.swift
+++ b/Sources/CoreHwp/Hwpx/Owpml/HwpxPageNumberMapper.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// `hp:pageNum`(쪽 번호 위치)을 `.pageNumberPosition(HwpPageNumberPosition)`으로
+/// 옮긴다 — 구역 부속 컨트롤(제어 문자 코드 21) 중 첫 typed 승격이다 (#135).
+///
+/// 조판(`HwpPageChromeBuilder`)은 typed 필드(`propertyInfo.displayPosition`·
+/// `numberFormat`·앞/뒤 장식 문자·`unused`)만 읽으므로 payload는 렌더 필수가
+/// 아니다. 표 147의 16바이트(4CC + 속성 UINT32 + WCHAR×4)를 합성해 바이너리
+/// 파싱 결과와 같은 모양을 유지한다 — 진단·매니페스트의 `rawPayload` 등식이
+/// 그대로 성립한다.
+///
+/// 실측 근거 (`Sources/CoreHwp/Hwpx/AGENTS.md` "쪽 번호 위치"): noori 변환 쌍
+/// (`BOTTOM_CENTER`↔5·`DIGIT`↔0·`sideChar=""`↔4번째 WCHAR 0, HWP 쌍 manifest
+/// `pageNumberPositions[0]`과 바이트 동일)과 2026-09-02 한글.app 12.30.0 쪽 번호
+/// 매기기 대화상자로 만든 .hwp/.hwpx 쌍 4종(`pos` 4값·`formatType` 4값·줄표
+/// 유무). 실측된 값이 전부 스키마 나열 순서 = 표 148·표 134 코드였으므로
+/// 미실측 값도 같은 규칙으로 채웠다.
+enum HwpxPageNumberMapper {
+    /// 제어 문자 코드 21(쪽 번호 위치) 앵커 + typed 컨트롤 — `classify`의 분기.
+    static func anchor(_ node: HwpxXMLNode, maxDepth: Int) -> HwpxRunChildAction {
+        .anchor(
+            code: 21,
+            fourCC: HwpOtherCtrlId.pageNumberPosition.rawValue,
+            ctrl: .pageNumberPosition(map(node, maxDepth: maxDepth))
+        )
+    }
+
+    static func map(_ node: HwpxXMLNode, maxDepth: Int) -> HwpPageNumberPosition {
+        let displayPosition = positions[node.attribute("pos") ?? "NONE"] ?? 0
+        let numberFormat = HwpxNumberFormatMapper.code(for: node.attribute("formatType"))
+        // sideChar는 표 147 4번째 WCHAR(줄표 문자, #138)에 대응한다 — 빈 문자열은
+        // 0(줄표 없음), 두 글자 이상이면 첫 UTF-16 unit(필드가 WCHAR 하나다).
+        // 앞/뒤 장식 문자는 HWPX에 대응 속성이 없어 0으로 둔다 — 헌법주석
+        // 실물도 줄표를 장식이 아니라 이 필드로 싣는다.
+        let sideChar: WCHAR = node.attribute("sideChar")?.utf16.first ?? 0
+
+        // 표현이 셋이다 — property·propertyInfo 필드·propertyInfo.rawValue.
+        // 바이너리는 load(property)가 셋을 함께 세우므로 여기서도 맞춘다.
+        var propertyInfo = HwpPageNumberPositionProperty()
+        propertyInfo.numberFormat = numberFormat
+        propertyInfo.displayPosition = displayPosition
+        propertyInfo.rawValue = UInt32(numberFormat & 0xFF)
+            | (UInt32(displayPosition & 0xF) << 8)
+
+        var payload = Data(capacity: 16)
+        payload.appendHwpxLittleEndian(HwpOtherCtrlId.pageNumberPosition.rawValue)
+        payload.appendHwpxLittleEndian(propertyInfo.rawValue)
+        payload.appendHwpxLittleEndian(WCHAR(0)) // 사용자 기호
+        payload.appendHwpxLittleEndian(WCHAR(0)) // 앞 장식 문자
+        payload.appendHwpxLittleEndian(WCHAR(0)) // 뒤 장식 문자
+        payload.appendHwpxLittleEndian(sideChar) // 줄표 문자 (공개 문서 '항상 "-"')
+
+        return HwpPageNumberPosition(
+            otherCtrlId: .pageNumberPosition,
+            property: propertyInfo.rawValue,
+            propertyInfo: propertyInfo,
+            userSymbol: 0,
+            headDecoration: 0,
+            tailDecoration: 0,
+            unused: sideChar,
+            unknown: 0,
+            rawPayload: payload,
+            rawTrailing: Data(),
+            // 속성만 읽는 잎 요소다 — 자식이 오면 전부 미소비라 진단으로
+            // 강등해야 "미해석 강등은 진단으로 보고됨" 규약이 지켜진다.
+            unknownChildren: node.unconsumedChildRecords(consumed: [], maxDepth: maxDepth)
+        )
+    }
+
+    /// OWPML `pos` → 표 148 bit 8-11 표시 위치 코드. 0 없음, 1~3 위(왼/가운데/
+    /// 오른), 4~6 아래(왼/가운데/오른), 7/8 바깥쪽 위/아래, 9/10 안쪽 위/아래 —
+    /// `HwpPageChromeBuilder.pageNumberPlacement`가 소비하는 코드다.
+    static let positions: [String: Int] = [
+        "NONE": 0,
+        "TOP_LEFT": 1,
+        "TOP_CENTER": 2,
+        "TOP_RIGHT": 3,
+        "BOTTOM_LEFT": 4,
+        "BOTTOM_CENTER": 5,
+        "BOTTOM_RIGHT": 6,
+        "OUTSIDE_TOP": 7,
+        "OUTSIDE_BOTTOM": 8,
+        "INSIDE_TOP": 9,
+        "INSIDE_BOTTOM": 10,
+    ]
+}

--- a/Sources/CoreHwp/Hwpx/Owpml/HwpxPageNumberMapper.swift
+++ b/Sources/CoreHwp/Hwpx/Owpml/HwpxPageNumberMapper.swift
@@ -5,9 +5,18 @@ import Foundation
 ///
 /// 조판(`HwpPageChromeBuilder`)은 typed 필드(`propertyInfo.displayPosition`·
 /// `numberFormat`·앞/뒤 장식 문자·`unused`)만 읽으므로 payload는 렌더 필수가
-/// 아니다. 표 147의 16바이트(4CC + 속성 UINT32 + WCHAR×4)를 합성해 바이너리
-/// 파싱 결과와 같은 모양을 유지한다 — 진단·매니페스트의 `rawPayload` 등식이
-/// 그대로 성립한다.
+/// 아니다. `.default`에서는 표 147의 16바이트(4CC + 속성 UINT32 + WCHAR×4)를
+/// 합성해 바이너리 파싱 결과와 같은 모양을 유지하고(noori 쌍의 HWP manifest와
+/// 바이트 동일), `.viewer`에서는 바이너리 경로(`DataReader.consumedData`)와 같이
+/// `preservedPayload` 게이트로 비운다 — 진단 walker는 `unknownChildren`만 읽어
+/// 양 모드 진단이 같다. `HwpxPictureMapper`의 73바이트는 렌더가
+/// `pictureProperty`로 재디코딩하는 decoupled 부류라 게이트 대상이 아니다.
+///
+/// 생략 속성은 OWPML(ParaList 스키마) `default` 선언을 따른다 — `pos`
+/// TOP_LEFT·`formatType` DIGIT·`sideChar` "-". 한글.app 실저장본은 세 속성을
+/// 항상 명시하므로 이 경로는 제3자 저장기용이고, 한글.app이 `<hp:pageNum/>`을
+/// 실제로 어떻게 그리는지는 실물이 없어 미검증이다. 미지 이름은 기본값으로
+/// 접지 않고 0(위치 없음·숫자)으로 둔다 — 위치를 추측해 그리지 않는다.
 ///
 /// 실측 근거 (`Sources/CoreHwp/Hwpx/AGENTS.md` "쪽 번호 위치"): noori 변환 쌍
 /// (`BOTTOM_CENTER`↔5·`DIGIT`↔0·`sideChar=""`↔4번째 WCHAR 0, HWP 쌍 manifest
@@ -17,22 +26,29 @@ import Foundation
 /// 미실측 값도 같은 규칙으로 채웠다.
 enum HwpxPageNumberMapper {
     /// 제어 문자 코드 21(쪽 번호 위치) 앵커 + typed 컨트롤 — `classify`의 분기.
-    static func anchor(_ node: HwpxXMLNode, maxDepth: Int) -> HwpxRunChildAction {
+    static func anchor(
+        _ node: HwpxXMLNode, context: HwpxMappingContext
+    ) -> HwpxRunChildAction {
         .anchor(
             code: 21,
             fourCC: HwpOtherCtrlId.pageNumberPosition.rawValue,
-            ctrl: .pageNumberPosition(map(node, maxDepth: maxDepth))
+            ctrl: .pageNumberPosition(map(node, context: context))
         )
     }
 
-    static func map(_ node: HwpxXMLNode, maxDepth: Int) -> HwpPageNumberPosition {
-        let displayPosition = positions[node.attribute("pos") ?? "NONE"] ?? 0
+    static func map(
+        _ node: HwpxXMLNode, context: HwpxMappingContext
+    ) -> HwpPageNumberPosition {
+        // 생략 → 스키마 기본값 TOP_LEFT(1), 미지 이름 → 0(위치 없음, 미렌더).
+        let displayPosition = positions[node.attribute("pos") ?? "TOP_LEFT"] ?? 0
+        // 생략 → DIGIT(0), 미지 이름 → 0 (HwpxNumberFormatMapper).
         let numberFormat = HwpxNumberFormatMapper.code(for: node.attribute("formatType"))
-        // sideChar는 표 147 4번째 WCHAR(줄표 문자, #138)에 대응한다 — 빈 문자열은
-        // 0(줄표 없음), 두 글자 이상이면 첫 UTF-16 unit(필드가 WCHAR 하나다).
-        // 앞/뒤 장식 문자는 HWPX에 대응 속성이 없어 0으로 둔다 — 헌법주석
-        // 실물도 줄표를 장식이 아니라 이 필드로 싣는다.
-        let sideChar: WCHAR = node.attribute("sideChar")?.utf16.first ?? 0
+        // sideChar는 표 147 4번째 WCHAR(줄표 문자, #138)에 대응한다. 생략은 스키마
+        // 기본값 "-"(0x2D), 명시 빈 문자열은 0(줄표 없음 — noori 실물), 두 글자
+        // 이상이면 첫 UTF-16 unit(필드가 WCHAR 하나다). 앞/뒤 장식 문자는 HWPX에
+        // 대응 속성이 없어 0으로 둔다 — 헌법주석 실물도 줄표를 장식이 아니라 이
+        // 필드로 싣는다.
+        let sideChar: WCHAR = (node.attribute("sideChar") ?? "-").utf16.first ?? 0
 
         // 표현이 셋이다 — property·propertyInfo 필드·propertyInfo.rawValue.
         // 바이너리는 load(property)가 셋을 함께 세우므로 여기서도 맞춘다.
@@ -59,11 +75,15 @@ enum HwpxPageNumberMapper {
             tailDecoration: 0,
             unused: sideChar,
             unknown: 0,
-            rawPayload: payload,
+            // 보존 전용 슬라이스 — 바이너리 pgnp가 `.viewer`에서 비워지는 것과
+            // 같은 게이트를 지난다 (HwpxPreviewMapper의 합성 payload와 같은 규약).
+            rawPayload: context.options.preservedPayload(payload),
             rawTrailing: Data(),
             // 속성만 읽는 잎 요소다 — 자식이 오면 전부 미소비라 진단으로
             // 강등해야 "미해석 강등은 진단으로 보고됨" 규약이 지켜진다.
-            unknownChildren: node.unconsumedChildRecords(consumed: [], maxDepth: maxDepth)
+            unknownChildren: node.unconsumedChildRecords(
+                consumed: [], maxDepth: context.unknownDepthLimit
+            )
         )
     }
 

--- a/Sources/CoreHwp/Hwpx/Owpml/HwpxPictureMapper.swift
+++ b/Sources/CoreHwp/Hwpx/Owpml/HwpxPictureMapper.swift
@@ -197,4 +197,10 @@ extension Data {
         append(UInt8((value >> 16) & 0xFF))
         append(UInt8((value >> 24) & 0xFF))
     }
+
+    /// WCHAR(UInt16) 필드용 — 표 147 쪽 번호 위치의 문자 4개처럼 2바이트 LE.
+    mutating func appendHwpxLittleEndian(_ value: UInt16) {
+        append(UInt8(value & 0xFF))
+        append(UInt8(value >> 8))
+    }
 }

--- a/Tests/CoreHwpTests/AGENTS.md
+++ b/Tests/CoreHwpTests/AGENTS.md
@@ -102,7 +102,9 @@ HWPX fixture는 **별도 루트** `Tests/CoreHwpTests/HwpxFixtures/<fixture-id>/
 정책은 `HwpxFixtures/README.md` 참조. 뷰어 계층 가드는
 `Tests/HwpKitTests/HwpxFixtureRenderTests.swift`다 — manifest `pageCount`를
 소비하고 HWP 쌍과 렌더 쪽수가 같은지 본다 (등가 스위트가 제외하는
-조판 캐시 `<hp:linesegarray>` 경로의 유일한 자동 회귀 가드).
+조판 캐시 `<hp:linesegarray>` 경로의 유일한 자동 회귀 가드). 쪽 크롬(머리말/
+꼬리말/쪽 번호) 블록 텍스트가 HWP 쌍과 같은지도 본다 (#135 — noori 각 쪽
+"1"·"2"·"3" 직접 핀 포함).
 
 **픽스처 추가는 이 타깃 밖으로도 번진다** (#80). `HwpKitCoreTests`의
 `HwpLayoutRenderParitySweepTests`가 `Fixtures/*/document.hwp`를 **디렉터리에서

--- a/Tests/CoreHwpTests/FixtureHarness/Hwpx/HwpxHwpEquivalenceTests.swift
+++ b/Tests/CoreHwpTests/FixtureHarness/Hwpx/HwpxHwpEquivalenceTests.swift
@@ -97,6 +97,19 @@ struct DocumentEquivalenceProjection {
         let horizontal: Int32
     }
 
+    /// 쪽 번호 위치(표 147) — HWPX `hp:pageNum`이 typed 승격돼야 HWP 쌍과
+    /// 같은 컨트롤이 선다 (#135). 강등 상태면 HWPX 쪽 배열이 비어 등식이
+    /// 깨진다. 4번째 WCHAR(`unused`)는 줄표 문자로 HWPX `sideChar`의 대응이다
+    /// (#138). payload 바이트는 비교하지 않는다 — 바이너리는 뒤에 미해석
+    /// UINT32가 붙은 20바이트 변형이 있어 포맷 무관 축이 아니다.
+    struct PageNumberPosition: Equatable {
+        let property: UInt32
+        let userSymbol: UInt16
+        let headDecoration: UInt16
+        let tailDecoration: UInt16
+        let sideChar: UInt16
+    }
+
     let sectionCount: Int
     let sectionParagraphCounts: [Int]
     let sectionTexts: [String]
@@ -105,6 +118,7 @@ struct DocumentEquivalenceProjection {
     let tableShapes: [TableShape]
     let tableAnchorOffsets: [AnchorOffset]
     let imageCount: Int
+    let pageNumberPositions: [PageNumberPosition]
 
     init(of file: HwpFile) {
         sectionCount = file.sectionArray.count
@@ -145,6 +159,15 @@ struct DocumentEquivalenceProjection {
             )
         }
         imageCount = HwpxFixtureAssertions.imageBinItemIds(from: file).count
+        pageNumberPositions = FixtureDerivedValues.pageNumberPositions(from: file).map {
+            PageNumberPosition(
+                property: $0.property,
+                userSymbol: $0.userSymbol,
+                headDecoration: $0.headDecoration,
+                tailDecoration: $0.tailDecoration,
+                sideChar: $0.unused
+            )
+        }
     }
 
     /// 인쇄 가능한 문자만 문서 순서(표 셀 재귀 포함)로 모은다 — 제어 문자
@@ -223,6 +246,10 @@ struct DocumentEquivalenceProjection {
         )
         expect(imageCount).to(
             equal(other.imageCount), description: "\(fixtureId) imageCount"
+        )
+        expect(pageNumberPositions).to(
+            equal(other.pageNumberPositions),
+            description: "\(fixtureId) pageNumberPositions"
         )
     }
 }

--- a/Tests/CoreHwpTests/Hwpx/HwpxPageNumberMapperTests.swift
+++ b/Tests/CoreHwpTests/Hwpx/HwpxPageNumberMapperTests.swift
@@ -1,0 +1,207 @@
+@testable import CoreHwp
+import Foundation
+import Nimble
+import XCTest
+
+/// `hp:pageNum` → `.pageNumberPosition` typed 매핑 — 속성 대응표·표 147 payload
+/// 합성·미소비 자식 강등을 합성 XML로 고정한다 (#135).
+final class HwpxPageNumberMapperTests: XCTestCase {
+    private struct UnexpectedControl: Error {
+        let ctrls: [HwpCtrlId]
+    }
+
+    /// 빈 구역 뒤에 `hp:ctrl` 하나를 가진 문단을 붙여 그 컨트롤을 꺼낸다.
+    private func mapPageNumber(
+        _ element: String
+    ) throws -> (paragraph: HwpParagraph, position: HwpPageNumberPosition) {
+        let section = try HwpxSectionFixture.mapSection(
+            HwpxSectionFixture.blankBody + """
+            <hp:p><hp:run charPrIDRef="7"><hp:ctrl>\(element)</hp:ctrl></hp:run>\
+            <hp:linesegarray><hp:lineseg textpos="0" vertpos="0" vertsize="1000" \
+            textheight="1000" baseline="850" spacing="600" horzpos="0" \
+            horzsize="42520" flags="393216"/></hp:linesegarray></hp:p>
+            """
+        )
+        let paragraph = section.paragraph[1]
+        let ctrls = try XCTUnwrap(paragraph.ctrlHeaderArray)
+        guard ctrls.count == 1, case let .pageNumberPosition(position) = ctrls[0] else {
+            throw UnexpectedControl(ctrls: ctrls)
+        }
+        return (paragraph, position)
+    }
+
+    func testNooriPageNumMapsToTypedControlWithBinaryIdenticalPayload() throws {
+        // noori 실저장본 그대로 — HWP 쌍의 pgnp는 property 0x0500, WCHAR 4개 전부 0
+        // (Fixtures/noori/manifest.json `pageNumberPositions[0]`).
+        let (paragraph, position) = try mapPageNumber(
+            "<hp:pageNum pos=\"BOTTOM_CENTER\" formatType=\"DIGIT\" sideChar=\"\"/>"
+        )
+        let chars = try XCTUnwrap(paragraph.paraText?.charArray)
+
+        // ext21(쪽 번호 위치) → 13. 합성 payload 선두 4바이트가 ctrl id다.
+        expect(chars.map(\.value)) == [21, 13]
+        expect(chars[0].type) == HwpCharType.extended
+        expect(chars[0].inlineControl?.rawControlId)
+            == HwpOtherCtrlId.pageNumberPosition.rawValue
+
+        expect(position.otherCtrlId) == HwpOtherCtrlId.pageNumberPosition
+        expect(position.property) == 0x0500
+        expect(position.propertyInfo.rawValue) == 0x0500
+        expect(position.propertyInfo.displayPosition) == 5
+        expect(position.propertyInfo.numberFormat) == 0
+        expect(position.userSymbol) == 0
+        expect(position.headDecoration) == 0
+        expect(position.tailDecoration) == 0
+        expect(position.unused) == 0
+        expect(position.unknown) == 0
+        expect(Array(position.rawPayload))
+            == [112, 110, 103, 112, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        expect(position.rawTrailing.isEmpty) == true
+        expect(position.unknownChildren).to(beEmpty())
+        // 분류 가능한 요소는 위치가 확실하므로 lineseg가 유지된다.
+        expect(paragraph.paraLineSeg.paraLineSegInternalArray.count) == 1
+    }
+
+    func testPositionsMapToTable148Codes() throws {
+        // 표 148 bit 8-11: 0 없음, 1~3 위, 4~6 아래, 7/8 바깥쪽, 9/10 안쪽.
+        let expected: [(name: String, code: Int)] = [
+            ("NONE", 0), ("TOP_LEFT", 1), ("TOP_CENTER", 2), ("TOP_RIGHT", 3),
+            ("BOTTOM_LEFT", 4), ("BOTTOM_CENTER", 5), ("BOTTOM_RIGHT", 6),
+            ("OUTSIDE_TOP", 7), ("OUTSIDE_BOTTOM", 8), ("INSIDE_TOP", 9), ("INSIDE_BOTTOM", 10),
+        ]
+        expect(expected.count) == HwpxPageNumberMapper.positions.count
+        for entry in expected {
+            let (_, position) = try mapPageNumber(
+                "<hp:pageNum pos=\"\(entry.name)\" formatType=\"DIGIT\" sideChar=\"\"/>"
+            )
+            expect(position.propertyInfo.displayPosition)
+                .to(equal(entry.code), description: entry.name)
+            // property 세 표현이 함께 선다.
+            expect(position.property)
+                .to(equal(UInt32(entry.code) << 8), description: entry.name)
+            expect(position.propertyInfo.rawValue)
+                .to(equal(position.property), description: entry.name)
+        }
+    }
+
+    func testFormatTypesMapToTable134Codes() throws {
+        // NumberType1 이름 순서 = 표 134 코드 순서 (HwpNumberFormat이 소비).
+        let expected: [(name: String, code: Int)] = [
+            ("DIGIT", 0), ("CIRCLED_DIGIT", 1), ("ROMAN_CAPITAL", 2), ("ROMAN_SMALL", 3),
+            ("LATIN_CAPITAL", 4), ("LATIN_SMALL", 5), ("CIRCLED_LATIN_CAPITAL", 6),
+            ("CIRCLED_LATIN_SMALL", 7), ("HANGUL_SYLLABLE", 8), ("CIRCLED_HANGUL_SYLLABLE", 9),
+            ("HANGUL_JAMO", 10), ("CIRCLED_HANGUL_JAMO", 11), ("HANGUL_PHONETIC", 12),
+            ("IDEOGRAPH", 13), ("CIRCLED_IDEOGRAPH", 14), ("DECAGON_CIRCLE", 15),
+            ("DECAGON_CIRCLE_HANJA", 16), ("SYMBOL", 0x80), ("USER_CHAR", 0x81),
+        ]
+        expect(expected.count) == HwpxNumberFormatMapper.codes.count
+        for entry in expected {
+            let (_, position) = try mapPageNumber(
+                "<hp:pageNum pos=\"BOTTOM_CENTER\" formatType=\"\(entry.name)\" sideChar=\"\"/>"
+            )
+            expect(position.propertyInfo.numberFormat)
+                .to(equal(entry.code), description: entry.name)
+            expect(position.property)
+                .to(equal(UInt32(entry.code) | 5 << 8), description: entry.name)
+        }
+    }
+
+    func testHangulAppMeasuredPairsMapToBinaryProperties() throws {
+        // 2026-09-02 한글.app 12.30.0 쪽 번호 매기기 대화상자로 만든 .hwp/.hwpx 쌍
+        // 4종 — 같은 문서의 HWPX 속성 ↔ HWP pgnp 속성·4번째 WCHAR
+        // (Sources/CoreHwp/Hwpx/AGENTS.md "쪽 번호 위치"). 줄표 넣기는 앞/뒤 장식이
+        // 아니라 4번째 WCHAR에만 실렸고 payload는 전부 16바이트였다.
+        struct MeasuredPair {
+            let pos: String
+            let format: String
+            let sideChar: String
+            let property: UInt32
+            let unused: UInt16
+        }
+        let measured: [MeasuredPair] = [
+            MeasuredPair(
+                pos: "OUTSIDE_TOP", format: "ROMAN_CAPITAL", sideChar: "-",
+                property: 0x0702, unused: 0x2D
+            ),
+            MeasuredPair(
+                pos: "INSIDE_BOTTOM", format: "DECAGON_CIRCLE_HANJA", sideChar: "",
+                property: 0x0A10, unused: 0
+            ),
+            MeasuredPair(
+                pos: "BOTTOM_LEFT", format: "HANGUL_SYLLABLE", sideChar: "-",
+                property: 0x0408, unused: 0x2D
+            ),
+            MeasuredPair(
+                pos: "TOP_CENTER", format: "CIRCLED_DIGIT", sideChar: "-",
+                property: 0x0201, unused: 0x2D
+            ),
+        ]
+        for pair in measured {
+            let (_, position) = try mapPageNumber(
+                "<hp:pageNum pos=\"\(pair.pos)\" formatType=\"\(pair.format)\" "
+                    + "sideChar=\"\(pair.sideChar)\"/>"
+            )
+            expect(position.property).to(equal(pair.property), description: pair.pos)
+            expect(position.unused).to(equal(pair.unused), description: pair.pos)
+            expect(position.headDecoration).to(equal(0), description: pair.pos)
+            expect(position.tailDecoration).to(equal(0), description: pair.pos)
+            expect(position.rawPayload.count).to(equal(16), description: pair.pos)
+        }
+    }
+
+    func testUnknownOrMissingEnumValuesFallBackToZero() throws {
+        // 미지 이름은 0(위치 없음·숫자)으로 — 뷰어도 범위 밖 코드를 숫자로 그린다.
+        let (_, unknown) = try mapPageNumber(
+            "<hp:pageNum pos=\"SIDEWAYS\" formatType=\"KLINGON\" sideChar=\"\"/>"
+        )
+        expect(unknown.propertyInfo.displayPosition) == 0
+        expect(unknown.propertyInfo.numberFormat) == 0
+        expect(unknown.property) == 0
+
+        // 속성이 전부 빠진 요소도 컨트롤 슬롯은 서야 WCHAR 정렬이 유지된다.
+        let (paragraph, missing) = try mapPageNumber("<hp:pageNum/>")
+        expect(paragraph.paraText?.charArray.map(\.value)) == [21, 13]
+        expect(missing.propertyInfo.displayPosition) == 0
+        expect(missing.propertyInfo.numberFormat) == 0
+        expect(missing.unused) == 0
+        expect(missing.rawPayload.count) == 16
+    }
+
+    func testSideCharLandsInFourthWcharOnly() throws {
+        // 줄표 필드(#138): 헌법주석 실물이 0x2D를 싣는 자리다. 앞/뒤 장식 문자는
+        // HWPX에 대응 속성이 없어 0으로 남는다 — 조판은 장식이 없을 때만 이
+        // 필드로 "- N -"을 만든다.
+        let (_, dash) = try mapPageNumber(
+            "<hp:pageNum pos=\"BOTTOM_CENTER\" formatType=\"DIGIT\" sideChar=\"-\"/>"
+        )
+        expect(dash.unused) == 0x2D
+        expect(dash.headDecoration) == 0
+        expect(dash.tailDecoration) == 0
+        expect(dash.userSymbol) == 0
+        expect(Array(dash.rawPayload.suffix(8))) == [0, 0, 0, 0, 0, 0, 0x2D, 0]
+
+        // 필드가 WCHAR 하나라 두 글자 이상이면 첫 UTF-16 unit만 싣는다.
+        let (_, multi) = try mapPageNumber("<hp:pageNum sideChar=\"★☆\"/>")
+        expect(multi.unused) == 0x2605
+    }
+
+    func testUnconsumedChildrenDegradeIntoDiagnostics() throws {
+        // 속성만 읽는 잎 요소 — 자식이 오면 값도 진단도 없이 사라지지 않고
+        // 합성 tagId(0) + 요소명 payload로 남아야 parseDiagnostics()가 본다.
+        let (_, position) = try mapPageNumber(
+            "<hp:pageNum pos=\"BOTTOM_CENTER\" formatType=\"DIGIT\" sideChar=\"\">"
+                + "<hp:extra/></hp:pageNum>"
+        )
+        let names = position.unknownChildren.compactMap {
+            String(bytes: $0.payload, encoding: .utf8)
+        }
+        expect(names) == ["extra"]
+        expect(position.unknownChildren.map(\.tagId)) == [hwpxSyntheticTagId]
+    }
+
+    func testPageNumIsNoLongerInDegradeTable() {
+        // 분류표 규약: 승격한 요소는 강등 표에서 빠져야 두 경로가 갈리지 않는다.
+        expect(HwpxControlMapper.sectionAttachments["pageNum"]).to(beNil())
+        expect(HwpxControlMapper.sectionAttachments["pageNumCtrl"]?.code) == 21
+    }
+}

--- a/Tests/CoreHwpTests/Hwpx/HwpxPageNumberMapperTests.swift
+++ b/Tests/CoreHwpTests/Hwpx/HwpxPageNumberMapperTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import Nimble
 import XCTest
 
-/// `hp:pageNum` → `.pageNumberPosition` typed 매핑 — 속성 대응표·표 147 payload
-/// 합성·미소비 자식 강등을 합성 XML로 고정한다 (#135).
+/// `hp:pageNum` → `.pageNumberPosition` typed 매핑 — 속성 대응표·스키마 기본값·
+/// 표 147 payload 합성·viewer 게이트·미소비 자식 강등을 합성 XML로 고정한다 (#135).
 final class HwpxPageNumberMapperTests: XCTestCase {
     private struct UnexpectedControl: Error {
         let ctrls: [HwpCtrlId]
@@ -12,7 +12,8 @@ final class HwpxPageNumberMapperTests: XCTestCase {
 
     /// 빈 구역 뒤에 `hp:ctrl` 하나를 가진 문단을 붙여 그 컨트롤을 꺼낸다.
     private func mapPageNumber(
-        _ element: String
+        _ element: String,
+        options: HwpLoadOptions = .default
     ) throws -> (paragraph: HwpParagraph, position: HwpPageNumberPosition) {
         let section = try HwpxSectionFixture.mapSection(
             HwpxSectionFixture.blankBody + """
@@ -20,7 +21,8 @@ final class HwpxPageNumberMapperTests: XCTestCase {
             <hp:linesegarray><hp:lineseg textpos="0" vertpos="0" vertsize="1000" \
             textheight="1000" baseline="850" spacing="600" horzpos="0" \
             horzsize="42520" flags="393216"/></hp:linesegarray></hp:p>
-            """
+            """,
+            options: options
         )
         let paragraph = section.paragraph[1]
         let ctrls = try XCTUnwrap(paragraph.ctrlHeaderArray)
@@ -149,22 +151,44 @@ final class HwpxPageNumberMapperTests: XCTestCase {
         }
     }
 
-    func testUnknownOrMissingEnumValuesFallBackToZero() throws {
-        // 미지 이름은 0(위치 없음·숫자)으로 — 뷰어도 범위 밖 코드를 숫자로 그린다.
-        let (_, unknown) = try mapPageNumber(
+    func testMissingAttributesUseOwpmlSchemaDefaults() throws {
+        // OWPML ParaList 스키마 default: pos TOP_LEFT·formatType DIGIT·sideChar "-".
+        // 한글.app은 세 속성을 항상 명시하므로 제3자 저장기용 경로다 — 생략을
+        // NONE(0)으로 접으면 스키마 유효 문서의 쪽 번호가 통째로 사라진다.
+        let (paragraph, missing) = try mapPageNumber("<hp:pageNum/>")
+        expect(paragraph.paraText?.charArray.map(\.value)) == [21, 13]
+        expect(missing.propertyInfo.displayPosition) == 1
+        expect(missing.propertyInfo.numberFormat) == 0
+        expect(missing.property) == 0x0100
+        expect(missing.propertyInfo.rawValue) == 0x0100
+        expect(missing.unused) == 0x2D
+        expect(Array(missing.rawPayload))
+            == [112, 110, 103, 112, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0x2D, 0]
+
+        // 속성별로 독립 기본값 — 일부만 적어도 나머지는 스키마 기본값.
+        let (_, partial) = try mapPageNumber("<hp:pageNum pos=\"BOTTOM_CENTER\"/>")
+        expect(partial.propertyInfo.displayPosition) == 5
+        expect(partial.unused) == 0x2D
+
+        // 명시 빈 문자열은 기본값이 아니라 '줄표 없음'이다 (noori 실물, #138).
+        let (_, emptySide) = try mapPageNumber("<hp:pageNum sideChar=\"\"/>")
+        expect(emptySide.propertyInfo.displayPosition) == 1
+        expect(emptySide.unused) == 0
+    }
+
+    func testUnknownEnumValuesFallBackToZero() throws {
+        // 미지 이름은 기본값으로 접지 않고 0(위치 없음·숫자) — 위치를 추측해
+        // 그리지 않는다. 뷰어도 범위 밖 번호 모양 코드를 숫자로 그린다. 컨트롤
+        // 슬롯은 서야 WCHAR 정렬이 유지된다.
+        let (paragraph, unknown) = try mapPageNumber(
             "<hp:pageNum pos=\"SIDEWAYS\" formatType=\"KLINGON\" sideChar=\"\"/>"
         )
+        expect(paragraph.paraText?.charArray.map(\.value)) == [21, 13]
         expect(unknown.propertyInfo.displayPosition) == 0
         expect(unknown.propertyInfo.numberFormat) == 0
         expect(unknown.property) == 0
-
-        // 속성이 전부 빠진 요소도 컨트롤 슬롯은 서야 WCHAR 정렬이 유지된다.
-        let (paragraph, missing) = try mapPageNumber("<hp:pageNum/>")
-        expect(paragraph.paraText?.charArray.map(\.value)) == [21, 13]
-        expect(missing.propertyInfo.displayPosition) == 0
-        expect(missing.propertyInfo.numberFormat) == 0
-        expect(missing.unused) == 0
-        expect(missing.rawPayload.count) == 16
+        expect(unknown.unused) == 0
+        expect(unknown.rawPayload.count) == 16
     }
 
     func testSideCharLandsInFourthWcharOnly() throws {
@@ -183,6 +207,37 @@ final class HwpxPageNumberMapperTests: XCTestCase {
         // 필드가 WCHAR 하나라 두 글자 이상이면 첫 UTF-16 unit만 싣는다.
         let (_, multi) = try mapPageNumber("<hp:pageNum sideChar=\"★☆\"/>")
         expect(multi.unused) == 0x2605
+    }
+
+    func testViewerOptionsEmptySynthesizedPayloadButKeepTypedFields() throws {
+        // `.viewer`는 보존용 rawPayload를 비운다 — 바이너리 pgnp가
+        // DataReader.consumedData로 비워지는 것과 패리티. typed 필드·앵커 WCHAR·
+        // 진단(unknownChildren — 합성 레코드는 옵션과 무관)은 양 모드 동일.
+        let element = "<hp:pageNum pos=\"BOTTOM_CENTER\" formatType=\"DIGIT\" sideChar=\"-\">"
+            + "<hp:extra/></hp:pageNum>"
+        let (defaultParagraph, preserved) = try mapPageNumber(element)
+        let (viewerParagraph, viewer) = try mapPageNumber(element, options: .viewer)
+
+        expect(preserved.rawPayload.count) == 16
+        expect(viewer.rawPayload).to(beEmpty())
+        expect(viewer.rawTrailing).to(beEmpty())
+        expect(viewer.property) == preserved.property
+        expect(viewer.propertyInfo.rawValue) == preserved.propertyInfo.rawValue
+        expect(viewer.propertyInfo.displayPosition) == 5
+        expect(viewer.unused) == 0x2D
+        expect(viewer.headDecoration) == preserved.headDecoration
+        expect(viewer.tailDecoration) == preserved.tailDecoration
+        expect(viewerParagraph.paraText?.charArray.map(\.value))
+            == defaultParagraph.paraText?.charArray.map(\.value)
+        expect(viewer.unknownChildren.map(\.payload)) == preserved.unknownChildren.map(\.payload)
+        expect(viewer.unknownChildren.count) == 1
+
+        // 게이트는 복구 옵션과 결합돼 있지 않다 — preserveRawPayload만 꺼도 같다.
+        let (_, optOut) = try mapPageNumber(
+            element, options: HwpLoadOptions(preserveRawPayload: false)
+        )
+        expect(optOut.rawPayload).to(beEmpty())
+        expect(optOut.property) == preserved.property
     }
 
     func testUnconsumedChildrenDegradeIntoDiagnostics() throws {

--- a/Tests/HwpKitTests/HwpxFixtureRenderTests.swift
+++ b/Tests/HwpKitTests/HwpxFixtureRenderTests.swift
@@ -101,6 +101,58 @@ final class HwpxFixtureRenderTests: XCTestCase {
         }
     }
 
+    /// 쪽 크롬(머리말/꼬리말/쪽 번호) 블록 텍스트가 HWP 쌍과 같아야 한다 —
+    /// HWPX `hp:pageNum`이 typed 승격돼야 noori 꼬리 쪽 번호가 선다 (#135).
+    /// 10쌍 중 쪽 크롬을 가진 문서는 noori(쪽 번호 위치 1건)뿐이라 나머지는
+    /// 빈 배열 등식이고, noori는 #138 이후 줄표 없는 "1"·"2"·"3"으로 직접
+    /// 핀한다 — 등식만 두면 양쪽이 함께 비어도 통과하기 때문이다.
+    func testHwpxPageChromeMatchesHwpPairs() async throws {
+        let hwpxFixtures = try FixtureRoot.loadAllHwpxFixtures(from: #file)
+        let hwpFixtures = try FixtureRoot.loadAllFixtures(from: #file)
+        let hwpByID = Dictionary(uniqueKeysWithValues: hwpFixtures.map { ($0.id, $0) })
+        let loader = HwpDocumentLoader(fontResolver: .testDeterministic)
+
+        var failures: [String] = []
+        var comparedCount = 0
+        var nooriChrome: [[String]]?
+        for fixture in hwpxFixtures where !fixture.hasExpectedError {
+            guard let pairID = fixture.sourceHwpFixture, let pair = hwpByID[pairID],
+                  !pair.hasExpectedError
+            else { continue }
+            comparedCount += 1
+            do {
+                let hwpx = try await loader.load(from: fixture.documentURL)
+                let hwp = try await loader.load(from: pair.documentURL)
+                let hwpxChrome = Self.pageChromeTexts(of: hwpx)
+                let hwpChrome = Self.pageChromeTexts(of: hwp)
+                if hwpxChrome != hwpChrome {
+                    failures.append("[\(fixture.id)] hwpx chrome \(hwpxChrome) != hwp \(hwpChrome)")
+                }
+                if fixture.id == "noori" {
+                    nooriChrome = hwpxChrome
+                }
+            } catch {
+                failures.append("[\(fixture.id)] load threw: \(error)")
+            }
+        }
+
+        expect(comparedCount) >= 10
+        expect(nooriChrome) == [["1"], ["2"], ["3"]]
+        if !failures.isEmpty {
+            fail("HWP↔HWPX page chrome mismatches (\(failures.count)):\n" +
+                failures.joined(separator: "\n"))
+        }
+    }
+
+    /// 페이지별 쪽 크롬 텍스트 블록 문자열 (문서 순서).
+    private static func pageChromeTexts(of document: HwpDocument) -> [[String]] {
+        document.pages.map { page in
+            page.blocks
+                .filter { $0.role == .pageChrome && $0.kind == .text }
+                .compactMap { $0.attributedString?.string }
+        }
+    }
+
     /// manifest `visibleTextContains`가 조판된 블록 텍스트에 그대로 있어야 한다 —
     /// HWP 쪽 `testAllFixturesRenderExpectedText`의 HWPX 판이다. 열 수 없는
     /// 픽스처(`expectedError`)는 문구를 갖지 않지만 규약을 한 곳에 모으려고


### PR DESCRIPTION
Closes #135

HWPX의 `<hp:pageNum>`을 `.notImplemented(pgnp)`에서 `HwpPageNumberPosition` 타입으로 승격해 HWPX 문서에서도 쪽 번호를 렌더링합니다. 뷰어 코드는 변경하지 않습니다.

## 요약

`noori` 변환 쌍에서는 HWPX 렌더링에만 각 페이지 하단의 쪽 번호가 누락됐습니다. `HwpxControlMapper.sectionAttachments`가 `pageNum`을 미구현 컨트롤로 강등해 조판기의 `pageChrome.register`에 전달되지 않았기 때문입니다.

이 변경으로 `noori` HWPX 세 쪽의 쪽 번호 텍스트가 HWP 쌍과 동일한 `"1"`·`"2"`·`"3"`으로 렌더링됩니다. 두 형식의 렌더링 PNG를 픽셀 단위로 비교하면 2·3쪽은 같고, 1쪽은 이 PR의 범위 밖인 글머리표 `-`(#133) 영역만 다릅니다.

<img width="1512" height="982" alt="hwpx-page-number-rendering" src="https://github.com/user-attachments/assets/b9e6fdec-d1df-4f5b-bca1-5b687799c149" />

_`noori` HWPX 2쪽 — `<hp:pageNum>`이 하단 중앙의 `2`로 렌더링됩니다._

## 구현

- **`HwpxPageNumberMapper`(신규)** — `pos`를 `displayPosition`(표 148의 비트 8~11), `formatType`을 `numberFormat`(표 134), `sideChar`를 네 번째 WCHAR인 `unused`(줄표 문자, #138)로 매핑합니다. 현재 확인한 `pageNum` 속성에는 사용자 기호와 앞·뒤 장식 문자의 직접 대응값이 없어 0으로 설정합니다. 조판기는 타입 필드만 사용하므로 표 147의 16바이트 payload는 보존용입니다. `.default`에서는 바이너리 `pgnp`와 같은 형식으로 합성하고, `.viewer`에서는 `preservedPayload` 게이트를 거쳐 비웁니다. WCHAR 기록을 위해 `Data.appendHwpxLittleEndian(UInt16)` 오버로드도 추가했습니다.
- **`HwpxNumberFormatMapper`(신규)** — OWPML `NumberType1`의 19개 값을 표 134 번호 모양 코드로 변환합니다. 현재는 `<hp:pageNum>`의 `formatType` 매핑에 사용하며, 같은 열거형을 쓰는 `hh:paraHead numFormat`(#133)과 `hp:autoNumFormat type`의 후속 매핑에서도 재사용할 수 있도록 공용 매퍼로 분리했습니다.
- **`HwpxControlMapper`** — `pageNum` 전용 분기를 추가하고 미구현 강등 목록인 `sectionAttachments`에서 제거했습니다.
- **생략 속성** — OWPML ParaList 스키마의 기본값(`pos="TOP_LEFT"`, `formatType="DIGIT"`, `sideChar="-"`)을 적용합니다. 명시적인 빈 문자열 `sideChar=""`는 0으로 처리해 줄표를 그리지 않습니다. 정의되지 않은 `pos`는 0(위치 없음, 미렌더링), `formatType`은 0(`DIGIT`)으로 처리합니다.
- **제외 범위** — `autoNum`·`newNum`·`pageNumCtrl`은 이번 PR에서 다루지 않습니다. HWPX 픽스처 10종에 해당 사례가 없으며, `noori`의 `hp:startNum page="0"`은 기존 매핑과 기본 카운터에 따라 1부터 셉니다.

## 리뷰 반영

- **생략 속성의 기본값** — 생략된 `pos`와 `sideChar`를 0으로 처리하던 동작을 스키마 기본값에 맞게 수정했습니다. 생략, 명시적인 빈 문자열, 정의되지 않은 값을 구분하는 테스트를 추가했습니다. `formatType`은 기존에도 `DIGIT`을 기본값으로 사용했습니다.
- **`.viewer`의 payload 보존 정책** — 합성한 payload가 옵션과 관계없이 남던 동작을 수정해 바이너리 `pgnp`와 동일하게 `preserveRawPayload` 옵션을 따르도록 했습니다. 타입 필드와 렌더링 결과는 그대로 유지됩니다. 그림 매퍼의 73바이트 payload는 렌더링 과정에서 다시 읽으므로 이 변경의 대상이 아닙니다. 또한 `rawPayload`가 진단이나 HWPX 매니페스트 등가 비교에 필요하다고 잘못 설명한 주석을 바로잡았습니다. 진단은 `unknownChildren`만 읽고, HWPX 등가 투영은 `rawPayload`를 비교하지 않습니다.

## 실측

이슈를 작성할 당시에는 `BOTTOM_CENTER`↔5와 `DIGIT`↔0만 실측했습니다. 이후 한글.app 12.30.0의 쪽 번호 매기기 대화상자로 문서 4종을 만들어 HWP와 HWPX로 각각 저장한 뒤, 두 형식의 `pgnp`와 `hp:pageNum` 속성을 대조했습니다.

| HWPX `pos` / `formatType` / `sideChar` | HWP `property` / 네 번째 WCHAR | 매핑 결과 |
|---|---|---|
| `BOTTOM_CENTER` / `DIGIT` / `""` (`noori`) | `0x0500` / `0` | 5 / 0 / 줄표 없음 |
| `OUTSIDE_TOP` / `ROMAN_CAPITAL` / `"-"` | `0x0702` / `0x2D` | 7 / 2 / 줄표 있음 |
| `INSIDE_BOTTOM` / `DECAGON_CIRCLE_HANJA` / `""` | `0x0A10` / `0` | 10 / 16 / 줄표 없음 |
| `BOTTOM_LEFT` / `HANGUL_SYLLABLE` / `"-"` | `0x0408` / `0x2D` | 4 / 8 / 줄표 있음 |
| `TOP_CENTER` / `CIRCLED_DIGIT` / `"-"` | `0x0201` / `0x2D` | 2 / 1 / 줄표 있음 |

실측한 `pos` 5개와 `formatType` 5개의 코드는 각각 스키마 나열 순서와 표 148·표 134의 코드가 일치했습니다. 나머지 값도 같은 규칙으로 매핑하고 `Sources/CoreHwp/Hwpx/AGENTS.md`의 ‘실파일 검증 대기 항목’에 기록했습니다. ‘줄표 넣기’는 앞·뒤 장식 WCHAR가 아니라 네 번째 WCHAR에만 저장됐고, 추가로 만든 네 쌍의 payload는 모두 16바이트였습니다. 이 네 쌍은 `testHangulAppMeasuredPairsMapToBinaryProperties`로 고정했으며 픽스처로는 커밋하지 않았습니다.

## 검증

- `HwpxPageNumberMapperTests` 10건으로 11개 위치, 19개 번호 형식, 스키마 기본값, 정의되지 않은 값의 폴백, `sideChar`, payload 보존 옵션과 한글.app 실측 쌍을 검증했습니다.
- `DocumentEquivalenceProjection.pageNumberPositions`에 `property`와 WCHAR 4개를 추가해 HWP와 HWPX의 파싱 결과를 비교합니다.
- `HwpxFixtureRenderTests.testHwpxPageChromeMatchesHwpPairs`에서 변환 쌍 10종의 쪽 크롬(머리말·꼬리말·쪽 번호) 텍스트가 같은지 확인하고, `noori`의 각 쪽을 `"1"`·`"2"`·`"3"`으로 직접 고정했습니다.
- `README.md`, `CHANGELOG.md`, CoreHwp와 HWPX의 `AGENTS.md`에 지원 범위와 검증 근거를 반영했습니다.
- `swiftformat --lint`와 `swiftlint`를 통과했고, 200ms를 넘는 식의 타입 검사 경고는 없었습니다. GitHub Actions의 macOS·iOS·Linux 테스트, DocC, Codecov 게이트도 모두 통과했습니다.
- 수동으로 HWP와 HWPX 렌더링 PNG를 비교한 결과, 2·3쪽은 일치했고 1쪽은 글머리표 `-`(#133) 영역만 달랐습니다.

## 후속

- #133의 글머리표 매핑에서 `HwpxNumberFormatMapper`를 `hh:paraHead numFormat`에 재사용합니다.
- #134의 차트 매핑은 `HwpxControlMapper`의 분류와 HWPX 문서의 범위 밖 목록을 함께 수정하므로 이 PR 이후 진행합니다.
- 강등 컨트롤(`degradedControl`)의 요소명 payload가 viewer 옵션과 관계없이 남는 기존 동작과 HWPX 픽스처 전체를 대상으로 하는 viewer 모드 스위프는 별도로 정리합니다.
- `<hp:pageNum/>`처럼 속성을 모두 생략한 문서를 한글.app이 실제로 어떻게 렌더링하는지는 제3자 저장기가 만든 문서를 확보한 뒤 대조합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
