### PR TITLE
chore(format): SwiftFormat 0.63.0의 redundantReturn 오류 8건 수정

### DIFF
--- a/Tests/CoreHwpTests/Assembly/ControlText/HwpFileListControlAssemblyTests.swift
+++ b/Tests/CoreHwpTests/Assembly/ControlText/HwpFileListControlAssemblyTests.swift
@@ -310,9 +310,9 @@ private func listControl(_ ctrlId: HwpOtherCtrlId, in hwp: HwpFile) -> HwpListCo
                  let (.footer, .footer(listControl)),
                  let (.footnote, .footnote(listControl)),
                  let (.endnote, .endnote(listControl)):
-                return listControl
+                listControl
             default:
-                return nil
+                nil
             }
         }
     }.last

--- a/Tests/CoreHwpTests/Assembly/ControlText/HwpFileRemainingOtherControlAssemblyTests.swift
+++ b/Tests/CoreHwpTests/Assembly/ControlText/HwpFileRemainingOtherControlAssemblyTests.swift
@@ -152,9 +152,9 @@ private func rawOtherControl(_ ctrlId: HwpOtherCtrlId, in hwp: HwpFile) -> HwpOt
                  let (.comment, .comment(other)),
                  let (.hiddenComment, .hiddenComment(other)),
                  let (.form, .form(other)):
-                return other
+                other
             default:
-                return nil
+                nil
             }
         }
     }.last

--- a/Tests/CoreHwpTests/FixtureHarness/FixtureRegression/FixtureDerivedValues.swift
+++ b/Tests/CoreHwpTests/FixtureHarness/FixtureRegression/FixtureDerivedValues.swift
@@ -204,9 +204,9 @@ enum FixtureDerivedValues {
                 case let .memo(control),
                      let .revision(control),
                      let .field(control):
-                    return control
+                    control
                 default:
-                    return nil
+                    nil
                 }
             }
     }
@@ -226,9 +226,9 @@ enum FixtureDerivedValues {
                      let .comment(control),
                      let .hiddenComment(control),
                      let .other(control):
-                    return control
+                    control
                 default:
-                    return nil
+                    nil
                 }
             }
     }


### PR DESCRIPTION
Closes #139

## 왜 지금인가

GitHub Actions macOS 러너에 SwiftFormat 0.63.0이 포함된 새 이미지가 배정되기 시작했다. #147의 `brew install swiftformat` 단계에는 `swiftformat 0.63.0 is already installed and up-to-date`가 출력됐고, 이 버전의 `redundantReturn` 규칙이 테스트 파일 3개에서 오류 8건을 보고했다. 반면 #148의 첫 CI에는 SwiftFormat 0.62.1이 설치된 이전 이미지가 배정돼, 현재 두 버전의 러너 이미지가 혼재한다.

따라서 **SwiftFormat 0.63.0 러너가 배정된 PR은 이 8건을 고치지 않으면 Lint에 실패한다.** #147에서 처음 이 문제가 드러났고, `main` 워크트리에서 `swiftformat --lint .`만 실행해 같은 3개 파일의 오류 8건을 재현했다. #139에서 “러너 이미지 상향 시 CI Lint 실패 예정”이라고 예고한 상황이 실제로 발생했다.

## 변경

암시적 반환이 가능한 `switch` 분기에서 불필요한 `return` 키워드 **8개만** 제거했으며, 그 외 포맷 변경은 없다.

| 파일 | 건수 |
| --- | ---: |
| `Tests/CoreHwpTests/FixtureHarness/FixtureRegression/FixtureDerivedValues.swift` | 4 |
| `Tests/CoreHwpTests/Assembly/ControlText/HwpFileRemainingOtherControlAssemblyTests.swift` | 2 |
| `Tests/CoreHwpTests/Assembly/ControlText/HwpFileListControlAssemblyTests.swift` | 2 |

`AGENTS.md`의 규칙에 따라 SwiftFormat은 **수정한 3개 파일에만** 실행했다. 로컬 SwiftFormat 버전은 오류를 재현한 #147 러너와 같은 0.63.0이다.

## 검증

- `swiftformat --lint .` (0.63.0): 저장소 전체 포맷 오류 **0건**
- `swiftlint`: 오류 **0건**
- `swift test`: 테스트 타깃 4개 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
